### PR TITLE
- fix: added color scheme to fix white iframe in dark mode

### DIFF
--- a/apps/shinkai-visor/src/components/popup/popup-embeder.ts
+++ b/apps/shinkai-visor/src/components/popup/popup-embeder.ts
@@ -19,6 +19,7 @@ iframe.setAttribute('src', chrome.runtime.getURL('src/components/popup/popup.htm
 iframe.style.border = 'none';
 iframe.style.width = '100%';
 iframe.style.height = '100%';
+iframe.style.colorScheme = 'only light'; 
 
 const shadow = baseContainer.attachShadow({ mode: 'open' });
 shadow.appendChild(iframe);


### PR DESCRIPTION
Fix dcSpark/shinkai-roadmap-internal#11

Added color-scheme light to avoid forced background white on iframes according to Chrome rules for [auto dark mode theme](https://developer.chrome.com/blog/auto-dark-theme/)