### PR TITLE
- improve: bumped versions

### DIFF
--- a/.github/workflows/pr-ci-healchecks.yml
+++ b/.github/workflows/pr-ci-healchecks.yml
@@ -38,8 +38,8 @@ jobs:
       - name: Download side binaries
         env:
           ARCH: x86_64-unknown-linux-gnu
-          SHINKAI_NODE_VERSION: v0.7.13
-          OLLAMA_VERSION: v0.1.44
+          SHINKAI_NODE_VERSION: v0.7.15
+          OLLAMA_VERSION: v0.1.47
         run: |
           npx ts-node ./ci-scripts/download-side-binaries.ts
 

--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -197,8 +197,8 @@ jobs:
       - name: Download side binaries
         env:
           ARCH: ${{ matrix.arch }}
-          SHINKAI_NODE_VERSION: v0.7.13
-          OLLAMA_VERSION: v0.1.44
+          SHINKAI_NODE_VERSION: v0.7.15
+          OLLAMA_VERSION: v0.1.47
         run: |
           npx ts-node ./ci-scripts/download-side-binaries.ts
 

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -195,8 +195,8 @@ jobs:
       - name: Download side binaries
         env:
           ARCH: ${{ matrix.arch }}
-          SHINKAI_NODE_VERSION: v0.7.13
-          OLLAMA_VERSION: v0.1.44
+          SHINKAI_NODE_VERSION: v0.7.15
+          OLLAMA_VERSION: v0.1.47
         run: |
           npx ts-node ./ci-scripts/download-side-binaries.ts
 

--- a/README.md
+++ b/README.md
@@ -40,23 +40,23 @@ $ git clone https://github.com/dcSpark/shinkai-apps
 #### Macos
 ```
 ARCH="aarch64-apple-darwin" \
-OLLAMA_VERSION="v0.1.44"\
-SHINKAI_NODE_VERSION="v0.7.13" \
+OLLAMA_VERSION="v0.1.47"\
+SHINKAI_NODE_VERSION="v0.7.15" \
 npx ts-node ./ci-scripts/download-side-binaries.ts
 ```
 
 #### Linux
 ```
 ARCH="x86_64-unknown-linux-gnu" \
-OLLAMA_VERSION="v0.1.44"\
-SHINKAI_NODE_VERSION="v0.7.13" \
+OLLAMA_VERSION="v0.1.47"\
+SHINKAI_NODE_VERSION="v0.7.15" \
 npx ts-node ./ci-scripts/download-side-binaries.ts
 ```
 
 #### Windows
 ```
-$ENV:OLLAMA_VERSION="v0.1.44"      
-$ENV:SHINKAI_NODE_VERSION="v0.7.13"
+$ENV:OLLAMA_VERSION="v0.1.47"      
+$ENV:SHINKAI_NODE_VERSION="v0.7.15"
 $ENV:ARCH="x86_64-pc-windows-msvc" 
 npx ts-node ./ci-scripts/download-side-binaries.ts
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@shinkai/source",
-  "version": "0.7.19",
+  "version": "0.7.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shinkai/source",
-  "version": "0.7.19",
+  "version": "0.7.20",
   "license": "SEE LICENSE IN LICENSE",
   "files": [
     "LICENSE"


### PR DESCRIPTION
Bump version to v0.7.20, including:
- shinkai-node v0.7.15
- ollama v0.1.47