### PR TITLE
- fix: downgrade ollama v0.1.48

### DIFF
--- a/.github/workflows/pr-ci-healchecks.yml
+++ b/.github/workflows/pr-ci-healchecks.yml
@@ -39,7 +39,7 @@ jobs:
         env:
           ARCH: x86_64-unknown-linux-gnu
           SHINKAI_NODE_VERSION: v0.7.18
-          OLLAMA_VERSION: v0.2.1
+          OLLAMA_VERSION: v0.1.48
         run: |
           npx ts-node ./ci-scripts/download-side-binaries.ts
 

--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -198,7 +198,7 @@ jobs:
         env:
           ARCH: ${{ matrix.arch }}
           SHINKAI_NODE_VERSION: v0.7.18
-          OLLAMA_VERSION: v0.2.1
+          OLLAMA_VERSION: v0.1.48
         run: |
           npx ts-node ./ci-scripts/download-side-binaries.ts
 

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -196,7 +196,7 @@ jobs:
         env:
           ARCH: ${{ matrix.arch }}
           SHINKAI_NODE_VERSION: v0.7.18
-          OLLAMA_VERSION: v0.2.1
+          OLLAMA_VERSION: v0.1.48
         run: |
           npx ts-node ./ci-scripts/download-side-binaries.ts
 

--- a/README.md
+++ b/README.md
@@ -40,23 +40,23 @@ $ git clone https://github.com/dcSpark/shinkai-apps
 #### Macos
 ```
 ARCH="aarch64-apple-darwin" \
-OLLAMA_VERSION="v0.2.1" \
-SHINKAI_NODE_VERSION="v0.7.17" \
+OLLAMA_VERSION="v0.1.48" \
+SHINKAI_NODE_VERSION="v0.7.18" \
 npx ts-node ./ci-scripts/download-side-binaries.ts
 ```
 
 #### Linux
 ```
 ARCH="x86_64-unknown-linux-gnu" \
-OLLAMA_VERSION="v0.2.1"\
-SHINKAI_NODE_VERSION="v0.7.17" \
+OLLAMA_VERSION="v0.1.48"\
+SHINKAI_NODE_VERSION="v0.7.18" \
 npx ts-node ./ci-scripts/download-side-binaries.ts
 ```
 
 #### Windows
 ```
-$ENV:OLLAMA_VERSION="v0.2.1"
-$ENV:SHINKAI_NODE_VERSION="v0.7.17"
+$ENV:OLLAMA_VERSION="v0.1.48"
+$ENV:SHINKAI_NODE_VERSION="v0.7.18"
 $ENV:ARCH="x86_64-pc-windows-msvc"
 npx ts-node ./ci-scripts/download-side-binaries.ts
 ```


### PR DESCRIPTION
ollama-0.2.1+assets is around 2gb+ and the limit for CAB files generated under the hood during the bundling process is 2gb so ollama 0.2.1 is broke our bundling system