### PR TITLE
- feature: add missing envs

### DIFF
--- a/apps/shinkai-desktop/src-tauri/src/commands/shinkai_node_manager_commands.rs
+++ b/apps/shinkai-desktop/src-tauri/src/commands/shinkai_node_manager_commands.rs
@@ -1,6 +1,5 @@
 use crate::globals::SHINKAI_NODE_MANAGER_INSTANCE;
 use crate::local_shinkai_node::process_handlers::logger::LogEntry;
-use crate::local_shinkai_node::process_handlers::shinkai_node_process_handler::ShinkaiNodeProcessHandler;
 use crate::local_shinkai_node::shinkai_node_options::ShinkaiNodeOptions;
 
 #[tauri::command]

--- a/apps/shinkai-desktop/src-tauri/src/commands/shinkai_node_manager_commands.rs
+++ b/apps/shinkai-desktop/src-tauri/src/commands/shinkai_node_manager_commands.rs
@@ -81,6 +81,6 @@ pub async fn shinkai_node_get_ollama_api_url() -> Result<String, String> {
 
 #[tauri::command]
 pub async fn shinkai_node_get_default_model() -> Result<String, String> {
-    let model = ShinkaiNodeProcessHandler::default_initial_model();
+    let model = ShinkaiNodeOptions::default_initial_model();
     Ok(model)
 }

--- a/apps/shinkai-desktop/src-tauri/src/hardware.rs
+++ b/apps/shinkai-desktop/src-tauri/src/hardware.rs
@@ -1,5 +1,3 @@
-use std::ptr::null;
-
 use serde::Serialize;
 use sysinfo::System;
 use wgpu::DeviceType;
@@ -90,7 +88,9 @@ fn get_total_vram(adapter: &wgpu::Adapter) -> u64 {
 pub fn hardware_get_summary() -> HardwareSummary {
     let instance = wgpu::Instance::default();
     let adapters = instance.enumerate_adapters(wgpu::Backends::all());
-    let adapter = adapters.iter().find(|adapter| adapter.get_info().device_type == wgpu::DeviceType::DiscreteGpu)
+    let adapter = adapters
+        .iter()
+        .find(|adapter| adapter.get_info().device_type == wgpu::DeviceType::DiscreteGpu)
         .unwrap_or_else(|| adapters.first().expect("no gpu adapter found"));
 
     let discrete_gpu = adapter.get_info().device_type == DeviceType::DiscreteGpu;

--- a/apps/shinkai-desktop/src-tauri/src/local_shinkai_node/process_handlers/shinkai_node_process_handler.rs
+++ b/apps/shinkai-desktop/src-tauri/src/local_shinkai_node/process_handlers/shinkai_node_process_handler.rs
@@ -3,10 +3,12 @@ use std::fs;
 use regex::Regex;
 use tokio::sync::mpsc::Sender;
 
-use crate::{hardware::{hardware_get_summary, RequirementsStatus}, local_shinkai_node::shinkai_node_options::ShinkaiNodeOptions};
+use crate::local_shinkai_node::shinkai_node_options::ShinkaiNodeOptions;
 
 use super::{
-    logger::LogEntry, process_handler::{ProcessHandler, ProcessHandlerEvent}, process_utils::options_to_env
+    logger::LogEntry,
+    process_handler::{ProcessHandler, ProcessHandlerEvent},
+    process_utils::options_to_env,
 };
 
 pub struct ShinkaiNodeProcessHandler {
@@ -20,10 +22,14 @@ impl ShinkaiNodeProcessHandler {
     const PROCESS_NAME: &'static str = "shinkai-node";
     const READY_MATCHER: &'static str = "listening on ";
 
-    pub fn new(event_sender: Sender<ProcessHandlerEvent>, default_node_storage_path: String) -> Self {
+    pub fn new(
+        event_sender: Sender<ProcessHandlerEvent>,
+        default_node_storage_path: String,
+    ) -> Self {
         let ready_matcher = Regex::new(Self::READY_MATCHER).unwrap();
-        let options = Self::default_options(default_node_storage_path.clone());
-        let process_handler = ProcessHandler::new(Self::PROCESS_NAME.to_string(), event_sender, ready_matcher);
+        let options = ShinkaiNodeOptions::with_storage_path(default_node_storage_path.clone());
+        let process_handler =
+            ProcessHandler::new(Self::PROCESS_NAME.to_string(), event_sender, ready_matcher);
         ShinkaiNodeProcessHandler {
             default_node_storage_path: default_node_storage_path.clone(),
             process_handler,
@@ -31,44 +37,8 @@ impl ShinkaiNodeProcessHandler {
         }
     }
 
-    pub fn default_initial_model() -> String {
-        let mut model = "llama3:8b-instruct-q4_1".to_string();
-        let hardware_summary = hardware_get_summary();
-        match hardware_summary.requirements_status {
-            RequirementsStatus::Minimum => {
-                model = "phi3:3.8b".to_string();
-            }
-            RequirementsStatus::StillUsable | RequirementsStatus::Unmeet => {
-                model = "qwen2:1.5b-instruct-q4_K_M".to_string();
-            }
-            _ => {}
-        }
-        model
-    }
-
-    pub fn default_options(default_node_storage_path: String) -> ShinkaiNodeOptions {
-        let initial_model = Self::default_initial_model();
-        let initial_agent_names = format!("o_{}", initial_model.replace(|c: char| !c.is_alphanumeric(), "_"));
-        let initial_agent_models = format!("ollama:{}", initial_model);
-        let options = ShinkaiNodeOptions {
-            port: Some("9550".to_string()),
-            node_ws_port: Some("9551".to_string()),
-            node_storage_path: Some(default_node_storage_path),
-            unstructured_server_url: Some("https://public.shinkai.com/x-un".to_string()),
-            embeddings_server_url: Some("http://127.0.0.1:11435".to_string()),
-            first_device_needs_registration_code: Some("false".to_string()),
-            initial_agent_urls: Some("http://127.0.0.1:11435".to_string()),
-            initial_agent_names: Some(initial_agent_names),
-            initial_agent_models: Some(initial_agent_models),
-            initial_agent_api_keys: Some("".to_string()),
-            starting_num_qr_devices: Some("0".to_string()),
-            log_all: Some("1".to_string()),
-        };
-        options
-    }
-
     fn get_base_url(&self) -> String {
-        let port = self.options.clone().port.unwrap();
+        let port = self.options.clone().node_port.unwrap();
         let base_url = format!("http://127.0.0.1:{}", port);
         base_url
     }
@@ -108,62 +78,7 @@ impl ShinkaiNodeProcessHandler {
     }
 
     pub fn set_options(&mut self, options: ShinkaiNodeOptions) -> ShinkaiNodeOptions {
-        let base_options = self.options.clone();
-        let merged_options = ShinkaiNodeOptions {
-            port: Some(options.port.unwrap_or_else(|| base_options.port.unwrap())),
-            node_ws_port: Some(options.node_ws_port.unwrap_or_else(|| base_options.node_ws_port.unwrap())),
-            node_storage_path: Some(
-                options
-                    .node_storage_path
-                    .unwrap_or_else(|| base_options.node_storage_path.unwrap()),
-            ),
-            unstructured_server_url: Some(
-                options
-                    .unstructured_server_url
-                    .unwrap_or_else(|| base_options.unstructured_server_url.unwrap()),
-            ),
-            embeddings_server_url: Some(
-                options
-                    .embeddings_server_url
-                    .unwrap_or_else(|| base_options.embeddings_server_url.unwrap()),
-            ),
-            first_device_needs_registration_code: Some(
-                options
-                    .first_device_needs_registration_code
-                    .unwrap_or_else(|| base_options.first_device_needs_registration_code.unwrap()),
-            ),
-            initial_agent_names: Some(
-                options
-                    .initial_agent_names
-                    .unwrap_or_else(|| base_options.initial_agent_names.unwrap()),
-            ),
-            initial_agent_urls: Some(
-                options
-                    .initial_agent_urls
-                    .unwrap_or_else(|| base_options.initial_agent_urls.unwrap()),
-            ),
-            initial_agent_models: Some(
-                options
-                    .initial_agent_models
-                    .unwrap_or_else(|| base_options.initial_agent_models.unwrap()),
-            ),
-            initial_agent_api_keys: Some(
-                options
-                    .initial_agent_api_keys
-                    .unwrap_or_else(|| base_options.initial_agent_api_keys.unwrap()),
-            ),
-            starting_num_qr_devices: Some(
-                options
-                    .starting_num_qr_devices
-                    .unwrap_or_else(|| base_options.starting_num_qr_devices.unwrap()),
-            ),
-            log_all: Some(
-                options
-                    .log_all
-                    .unwrap_or_else(|| base_options.log_all.unwrap()),
-            ),
-        };
-        self.options = merged_options;
+        self.options = ShinkaiNodeOptions::from_merge(self.options.clone(), options);
         self.options.clone()
     }
 
@@ -196,7 +111,8 @@ impl ShinkaiNodeProcessHandler {
     }
 
     pub fn set_default_options(&mut self) -> ShinkaiNodeOptions {
-        self.options = Self::default_options(self.default_node_storage_path.clone());
+        self.options =
+            ShinkaiNodeOptions::with_storage_path(self.default_node_storage_path.clone());
         self.options.clone()
     }
 

--- a/apps/shinkai-desktop/src-tauri/src/local_shinkai_node/process_handlers/shinkai_node_process_handler.rs
+++ b/apps/shinkai-desktop/src-tauri/src/local_shinkai_node/process_handlers/shinkai_node_process_handler.rs
@@ -38,8 +38,9 @@ impl ShinkaiNodeProcessHandler {
     }
 
     fn get_base_url(&self) -> String {
-        let port = self.options.clone().node_port.unwrap();
-        let base_url = format!("http://127.0.0.1:{}", port);
+        let ip = self.options.clone().node_api_ip.unwrap();
+        let port = self.options.clone().node_api_port.unwrap();
+        let base_url = format!("http://{}:{}", ip, port);
         base_url
     }
 

--- a/apps/shinkai-desktop/src-tauri/src/local_shinkai_node/shinkai_node_manager.rs
+++ b/apps/shinkai-desktop/src-tauri/src/local_shinkai_node/shinkai_node_manager.rs
@@ -34,7 +34,6 @@ pub enum ShinkaiNodeManagerEvent {
 }
 
 pub struct ShinkaiNodeManager {
-    default_node_storage_path: String,
     ollama_process: OllamaProcessHandler,
     shinkai_node_process: ShinkaiNodeProcessHandler,
     event_broadcaster: broadcast::Sender<ShinkaiNodeManagerEvent>,
@@ -47,7 +46,6 @@ impl ShinkaiNodeManager {
         let (event_broadcaster, _) = broadcast::channel(10);
 
         ShinkaiNodeManager {
-            default_node_storage_path: default_node_storage_path.clone(),
             ollama_process: OllamaProcessHandler::new(
                 None,
                 ollama_sender,

--- a/apps/shinkai-desktop/src-tauri/src/local_shinkai_node/shinkai_node_manager.rs
+++ b/apps/shinkai-desktop/src-tauri/src/local_shinkai_node/shinkai_node_manager.rs
@@ -148,9 +148,7 @@ impl ShinkaiNodeManager {
         }
         
 
-        let mut default_model = ShinkaiNodeProcessHandler::default_options(self.default_node_storage_path.clone())
-            .initial_agent_models
-            .unwrap();
+        let mut default_model = ShinkaiNodeOptions::default().initial_agent_models.unwrap();
         default_model = default_model.replace("ollama:", "");
 
         if !installed_models.contains(&default_model.to_string()) {

--- a/apps/shinkai-desktop/src-tauri/src/local_shinkai_node/shinkai_node_options.rs
+++ b/apps/shinkai-desktop/src-tauri/src/local_shinkai_node/shinkai_node_options.rs
@@ -1,10 +1,16 @@
 use serde::{Deserialize, Serialize};
 
+use crate::hardware::{hardware_get_summary, RequirementsStatus};
+
 /// It matches ENV variables names from ShinkaiNode
 #[derive(Serialize, Deserialize, Clone)]
 pub struct ShinkaiNodeOptions {
-    pub port: Option<String>,
+    pub node_api_ip: Option<String>,
+    pub node_api_port: Option<String>,
     pub node_ws_port: Option<String>,
+    pub node_ip: Option<String>,
+    pub node_port: Option<String>,
+    pub global_identity_name: Option<String>,
     pub node_storage_path: Option<String>,
     pub unstructured_server_url: Option<String>,
     pub embeddings_server_url: Option<String>,
@@ -15,4 +21,159 @@ pub struct ShinkaiNodeOptions {
     pub initial_agent_api_keys: Option<String>,
     pub starting_num_qr_devices: Option<String>,
     pub log_all: Option<String>,
+    pub proxy_identity: Option<String>,
+    pub rpc_url: Option<String>,
+}
+
+impl ShinkaiNodeOptions {
+    pub fn with_storage_path(default_node_storage_path: String) -> ShinkaiNodeOptions {
+        ShinkaiNodeOptions {
+            node_storage_path: Some(default_node_storage_path),
+            ..Default::default()
+        }
+    }
+
+    pub fn default_initial_model() -> String {
+        let mut model = "llama3:8b-instruct-q4_1".to_string();
+        let hardware_summary = hardware_get_summary();
+        match hardware_summary.requirements_status {
+            RequirementsStatus::Minimum => {
+                model = "phi3:3.8b".to_string();
+            }
+            RequirementsStatus::StillUsable | RequirementsStatus::Unmeet => {
+                model = "qwen2:1.5b-instruct-q4_K_M".to_string();
+            }
+            _ => {}
+        }
+        model
+    }
+
+    pub fn from_merge(
+        base_options: ShinkaiNodeOptions,
+        options: ShinkaiNodeOptions,
+    ) -> ShinkaiNodeOptions {
+        ShinkaiNodeOptions {
+            node_api_ip: Some(
+                options
+                    .node_api_ip
+                    .unwrap_or_else(|| base_options.node_api_ip.unwrap()),
+            ),
+            node_api_port: Some(
+                options
+                    .node_api_port
+                    .unwrap_or_else(|| base_options.node_api_port.unwrap()),
+            ),
+            node_ws_port: Some(
+                options
+                    .node_ws_port
+                    .unwrap_or_else(|| base_options.node_ws_port.unwrap()),
+            ),
+            node_ip: Some(
+                options
+                    .node_ip
+                    .unwrap_or_else(|| base_options.node_ip.unwrap()),
+            ),
+            node_port: Some(
+                options
+                    .node_port
+                    .unwrap_or_else(|| base_options.node_port.unwrap()),
+            ),
+            global_identity_name: Some(
+                options
+                    .global_identity_name
+                    .unwrap_or_else(|| base_options.global_identity_name.unwrap()),
+            ),
+            node_storage_path: Some(
+                options
+                    .node_storage_path
+                    .unwrap_or_else(|| base_options.node_storage_path.unwrap()),
+            ),
+            unstructured_server_url: Some(
+                options
+                    .unstructured_server_url
+                    .unwrap_or_else(|| base_options.unstructured_server_url.unwrap()),
+            ),
+            embeddings_server_url: Some(
+                options
+                    .embeddings_server_url
+                    .unwrap_or_else(|| base_options.embeddings_server_url.unwrap()),
+            ),
+            first_device_needs_registration_code: Some(
+                options
+                    .first_device_needs_registration_code
+                    .unwrap_or_else(|| base_options.first_device_needs_registration_code.unwrap()),
+            ),
+            initial_agent_names: Some(
+                options
+                    .initial_agent_names
+                    .unwrap_or_else(|| base_options.initial_agent_names.unwrap()),
+            ),
+            initial_agent_urls: Some(
+                options
+                    .initial_agent_urls
+                    .unwrap_or_else(|| base_options.initial_agent_urls.unwrap()),
+            ),
+            initial_agent_models: Some(
+                options
+                    .initial_agent_models
+                    .unwrap_or_else(|| base_options.initial_agent_models.unwrap()),
+            ),
+            initial_agent_api_keys: Some(
+                options
+                    .initial_agent_api_keys
+                    .unwrap_or_else(|| base_options.initial_agent_api_keys.unwrap()),
+            ),
+            starting_num_qr_devices: Some(
+                options
+                    .starting_num_qr_devices
+                    .unwrap_or_else(|| base_options.starting_num_qr_devices.unwrap()),
+            ),
+            log_all: Some(
+                options
+                    .log_all
+                    .unwrap_or_else(|| base_options.log_all.unwrap()),
+            ),
+            proxy_identity: Some(
+                options
+                    .proxy_identity
+                    .unwrap_or_else(|| base_options.proxy_identity.unwrap()),
+            ),
+            rpc_url: Some(
+                options
+                    .rpc_url
+                    .unwrap_or_else(|| base_options.rpc_url.unwrap()),
+            ),
+        }
+    }
+}
+
+impl Default for ShinkaiNodeOptions {
+    fn default() -> ShinkaiNodeOptions {
+        let initial_model = Self::default_initial_model();
+        let initial_agent_names = format!(
+            "o_{}",
+            initial_model.replace(|c: char| !c.is_alphanumeric(), "_")
+        );
+        let initial_agent_models = format!("ollama:{}", initial_model);
+        ShinkaiNodeOptions {
+            node_api_ip: Some("127.0.0.1".to_string()),
+            node_api_port: Some("9550".to_string()),
+            node_ws_port: Some("9551".to_string()),
+            node_ip: Some("127.0.0.1".to_string()),
+            node_port: Some("9552".to_string()),
+            global_identity_name: Some("@@localhost.arb-sep-shinkai".to_string()),
+            node_storage_path: Some("./".to_string()),
+            unstructured_server_url: Some("https://public.shinkai.com/x-un".to_string()),
+            embeddings_server_url: Some("http://127.0.0.1:11435".to_string()),
+            first_device_needs_registration_code: Some("false".to_string()),
+            initial_agent_urls: Some("http://127.0.0.1:11435".to_string()),
+            initial_agent_names: Some(initial_agent_names),
+            initial_agent_models: Some(initial_agent_models),
+            initial_agent_api_keys: Some("".to_string()),
+            starting_num_qr_devices: Some("0".to_string()),
+            log_all: Some("1".to_string()),
+            proxy_identity: Some("@@relayer_pub_01.arb-sep-shinkai".to_string()),
+            rpc_url: Some("https://public.stackup.sh/api/v1/node/arbitrum-sepolia".to_string()),
+        }
+    }
 }


### PR DESCRIPTION
Added missing shinkai-node envs:
- NODE_IP
- NODE_PORT
- NODE_API_IP
- NODE_API_PORT
- GLOBAL_IDENTITY_NAME
- PROXY_IDENTITY
- RPC_URL

Refactor ShinkaiNodeOptions to encapsulate shinkai-node options logic.