### PR TITLE
- feature: support spanish embeddings

### DIFF
--- a/.github/workflows/pr-ci-healchecks.yml
+++ b/.github/workflows/pr-ci-healchecks.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Download side binaries
         env:
           ARCH: x86_64-unknown-linux-gnu
-          SHINKAI_NODE_VERSION: v0.7.21
+          SHINKAI_NODE_VERSION: v0.7.22
           OLLAMA_VERSION: v0.1.48
         run: |
           npx ts-node ./ci-scripts/download-side-binaries.ts

--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -197,7 +197,7 @@ jobs:
       - name: Download side binaries
         env:
           ARCH: ${{ matrix.arch }}
-          SHINKAI_NODE_VERSION: v0.7.21
+          SHINKAI_NODE_VERSION: v0.7.22
           OLLAMA_VERSION: v0.1.48
         run: |
           npx ts-node ./ci-scripts/download-side-binaries.ts

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -195,7 +195,7 @@ jobs:
       - name: Download side binaries
         env:
           ARCH: ${{ matrix.arch }}
-          SHINKAI_NODE_VERSION: v0.7.21
+          SHINKAI_NODE_VERSION: v0.7.22
           OLLAMA_VERSION: v0.1.48
         run: |
           npx ts-node ./ci-scripts/download-side-binaries.ts

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ $ git clone https://github.com/dcSpark/shinkai-apps
 ```
 ARCH="aarch64-apple-darwin" \
 OLLAMA_VERSION="v0.1.48" \
-SHINKAI_NODE_VERSION="v0.7.21" \
+SHINKAI_NODE_VERSION="v0.7.22" \
 npx ts-node ./ci-scripts/download-side-binaries.ts
 ```
 
@@ -49,14 +49,14 @@ npx ts-node ./ci-scripts/download-side-binaries.ts
 ```
 ARCH="x86_64-unknown-linux-gnu" \
 OLLAMA_VERSION="v0.1.48"\
-SHINKAI_NODE_VERSION="v0.7.21" \
+SHINKAI_NODE_VERSION="v0.7.22" \
 npx ts-node ./ci-scripts/download-side-binaries.ts
 ```
 
 #### Windows
 ```
 $ENV:OLLAMA_VERSION="v0.1.48"
-$ENV:SHINKAI_NODE_VERSION="v0.7.21"
+$ENV:SHINKAI_NODE_VERSION="v0.7.22"
 $ENV:ARCH="x86_64-pc-windows-msvc"
 npx ts-node ./ci-scripts/download-side-binaries.ts
 ```

--- a/apps/shinkai-desktop/src-tauri/Cargo.toml
+++ b/apps/shinkai-desktop/src-tauri/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2021"
 tauri-build = { version = "1.4", features = [] }
 
 [dependencies]
-tauri = { version = "1.4", features = [ "process-relaunch", "updater", "window-set-focus", "http-request", "window-create", "shell-sidecar", "os-all", "notification-all", "path-all", "dialog-all", "window-close", "window-start-dragging", "macos-private-api", "fs-all", "global-shortcut-all", "system-tray", "shell-open", "process-command-api"] }
+tauri = { version = "1.4", features = [ "updater", "process-relaunch", "window-set-focus", "http-request", "window-create", "shell-sidecar", "os-all", "notification-all", "path-all", "dialog-all", "window-close", "window-start-dragging", "macos-private-api", "fs-all", "global-shortcut-all", "system-tray", "shell-open", "process-command-api"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 whisper-rs = "0.8.0"

--- a/apps/shinkai-desktop/src-tauri/src/local_shinkai_node/shinkai_node_manager.rs
+++ b/apps/shinkai-desktop/src-tauri/src/local_shinkai_node/shinkai_node_manager.rs
@@ -97,7 +97,7 @@ impl ShinkaiNodeManager {
             return Err(e.to_string());
         }
         let installed_models: Vec<String> = installed_models_response.unwrap().models.iter().map(|m| m.model.clone()).collect();
-        let default_embeddings_model = "snowflake-arctic-embed:xs";
+        let default_embeddings_model = "jina/jina-embeddings-v2-base-es";
         if !installed_models.contains(&default_embeddings_model.to_string()) {
             self.emit_event(ShinkaiNodeManagerEvent::PullingModelStart {
                 model: default_embeddings_model.to_string(),

--- a/apps/shinkai-desktop/src-tauri/src/local_shinkai_node/shinkai_node_manager.rs
+++ b/apps/shinkai-desktop/src-tauri/src/local_shinkai_node/shinkai_node_manager.rs
@@ -97,12 +97,12 @@ impl ShinkaiNodeManager {
             return Err(e.to_string());
         }
         let installed_models: Vec<String> = installed_models_response.unwrap().models.iter().map(|m| m.model.clone()).collect();
-        let default_embeddings_model = "jina/jina-embeddings-v2-base-es";
-        if !installed_models.contains(&default_embeddings_model.to_string()) {
+        let default_embedding_model = ShinkaiNodeOptions::default().default_embedding_model.unwrap();
+        if !installed_models.contains(&default_embedding_model.to_string()) {
             self.emit_event(ShinkaiNodeManagerEvent::PullingModelStart {
-                model: default_embeddings_model.to_string(),
+                model: default_embedding_model.to_string(),
             });
-            match ollama_api.pull_stream(default_embeddings_model).await {
+            match ollama_api.pull_stream(&default_embedding_model).await {
                 Ok(mut stream) => {
                     while let Some(stream_value) = stream.next().await {
                         match stream_value {
@@ -115,7 +115,7 @@ impl ShinkaiNodeManager {
                                 } = value
                                 {
                                     self.emit_event(ShinkaiNodeManagerEvent::PullingModelProgress {
-                                        model: default_embeddings_model.to_string(),
+                                        model: default_embedding_model.to_string(),
                                         progress: (completed as f32 / total as f32 * 100.0) as u32,
                                     });
                                 }
@@ -123,7 +123,7 @@ impl ShinkaiNodeManager {
                             Err(e) => {
                                 self.kill().await;
                                 self.emit_event(ShinkaiNodeManagerEvent::PullingModelError {
-                                    model: default_embeddings_model.to_string(),
+                                    model: default_embedding_model.to_string(),
                                     error: e.to_string(),
                                 });
                                 return Err(e.to_string())
@@ -134,14 +134,14 @@ impl ShinkaiNodeManager {
                 Err(e) => {
                     self.kill().await;
                     self.emit_event(ShinkaiNodeManagerEvent::PullingModelError {
-                        model: default_embeddings_model.to_string(),
+                        model: default_embedding_model.to_string(),
                         error: e.to_string(),
                     });
                     return Err(e.to_string());
                 }
             }
             self.emit_event(ShinkaiNodeManagerEvent::PullingModelDone {
-                model: default_embeddings_model.to_string(),
+                model: default_embedding_model.to_string(),
             });
         }
         

--- a/apps/shinkai-desktop/src-tauri/src/local_shinkai_node/shinkai_node_options.rs
+++ b/apps/shinkai-desktop/src-tauri/src/local_shinkai_node/shinkai_node_options.rs
@@ -186,8 +186,8 @@ impl Default for ShinkaiNodeOptions {
             log_all: Some("1".to_string()),
             proxy_identity: Some("@@relayer_pub_01.arb-sep-shinkai".to_string()),
             rpc_url: Some("https://public.stackup.sh/api/v1/node/arbitrum-sepolia".to_string()),
-            default_embedding_model: Some("jina/jina-embeddings-v2-base-es:latest".to_string()),
-            supported_embedding_models: Some("jina/jina-embeddings-v2-base-es:latest".to_string()),
+            default_embedding_model: Some("snowflake-arctic-embed:xs".to_string()),
+            supported_embedding_models: Some("snowflake-arctic-embed:xs".to_string()),
         }
     }
 }

--- a/apps/shinkai-desktop/src-tauri/src/local_shinkai_node/shinkai_node_options.rs
+++ b/apps/shinkai-desktop/src-tauri/src/local_shinkai_node/shinkai_node_options.rs
@@ -23,6 +23,8 @@ pub struct ShinkaiNodeOptions {
     pub log_all: Option<String>,
     pub proxy_identity: Option<String>,
     pub rpc_url: Option<String>,
+    pub default_embedding_model: Option<String>,
+    pub supported_embedding_models: Option<String>,
 }
 
 impl ShinkaiNodeOptions {
@@ -143,6 +145,16 @@ impl ShinkaiNodeOptions {
                     .rpc_url
                     .unwrap_or_else(|| base_options.rpc_url.unwrap()),
             ),
+            default_embedding_model: Some(
+                options
+                    .default_embedding_model
+                    .unwrap_or_else(|| base_options.default_embedding_model.unwrap()),
+            ),
+            supported_embedding_models: Some(
+                options
+                    .supported_embedding_models
+                    .unwrap_or_else(|| base_options.supported_embedding_models.unwrap()),
+            ),
         }
     }
 }
@@ -174,6 +186,8 @@ impl Default for ShinkaiNodeOptions {
             log_all: Some("1".to_string()),
             proxy_identity: Some("@@relayer_pub_01.arb-sep-shinkai".to_string()),
             rpc_url: Some("https://public.stackup.sh/api/v1/node/arbitrum-sepolia".to_string()),
+            default_embedding_model: Some("jina/jina-embeddings-v2-base-es:latest".to_string()),
+            supported_embedding_models: Some("jina/jina-embeddings-v2-base-es:latest".to_string()),
         }
     }
 }

--- a/apps/shinkai-desktop/src-tauri/tauri.conf.development.json
+++ b/apps/shinkai-desktop/src-tauri/tauri.conf.development.json
@@ -7,6 +7,7 @@
       "identifier": "com.shinkai.desktop.dev"
     },
     "updater": {
+      "active": false,
       "endpoints": [
         "https://download.shinkai.com/shinkai-desktop/binaries/development/updates.json"
       ],

--- a/apps/shinkai-desktop/src-tauri/tauri.conf.development.json
+++ b/apps/shinkai-desktop/src-tauri/tauri.conf.development.json
@@ -7,7 +7,6 @@
       "identifier": "com.shinkai.desktop.dev"
     },
     "updater": {
-      "active": true,
       "endpoints": [
         "https://download.shinkai.com/shinkai-desktop/binaries/development/updates.json"
       ],

--- a/apps/shinkai-desktop/src-tauri/tauri.conf.development.json
+++ b/apps/shinkai-desktop/src-tauri/tauri.conf.development.json
@@ -7,7 +7,7 @@
       "identifier": "com.shinkai.desktop.dev"
     },
     "updater": {
-      "active": false,
+      "active": true,
       "endpoints": [
         "https://download.shinkai.com/shinkai-desktop/binaries/development/updates.json"
       ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@shinkai/source",
-  "version": "0.7.22",
+  "version": "0.7.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shinkai/source",
-  "version": "0.7.22",
+  "version": "0.7.23",
   "license": "SEE LICENSE IN LICENSE",
   "files": [
     "LICENSE"


### PR DESCRIPTION
Now in advanced shinkai-node options we can set the default embeddings model using:
```
DEFAULT_EMBEDDING_MODEL
SUPPORTED_EMBEDDING_MODELS
```

IE for Spanish
![image](https://github.com/user-attachments/assets/593118bb-7ad7-4e44-83dd-94998b98900b)


