### PR TITLE
- improve: local data state

### DIFF
--- a/.github/workflows/pr-ci-healchecks.yml
+++ b/.github/workflows/pr-ci-healchecks.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Download side binaries
         env:
           ARCH: x86_64-unknown-linux-gnu
-          SHINKAI_NODE_VERSION: v0.7.27
+          SHINKAI_NODE_VERSION: v0.7.28
           OLLAMA_VERSION: v0.3.1
         run: |
           npx ts-node ./ci-scripts/download-side-binaries.ts

--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -210,7 +210,7 @@ jobs:
       - name: Download side binaries
         env:
           ARCH: ${{ matrix.arch }}
-          SHINKAI_NODE_VERSION: v0.7.27
+          SHINKAI_NODE_VERSION: v0.7.28
           OLLAMA_VERSION: v0.3.1
         run: |
           npx ts-node ./ci-scripts/download-side-binaries.ts

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -208,7 +208,7 @@ jobs:
       - name: Download side binaries
         env:
           ARCH: ${{ matrix.arch }}
-          SHINKAI_NODE_VERSION: v0.7.27
+          SHINKAI_NODE_VERSION: v0.7.28
           OLLAMA_VERSION: v0.3.1
         run: |
           npx ts-node ./ci-scripts/download-side-binaries.ts

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ $ git clone https://github.com/dcSpark/shinkai-apps
 ```
 ARCH="aarch64-apple-darwin" \
 OLLAMA_VERSION="v0.3.1" \
-SHINKAI_NODE_VERSION="v0.7.27" \
+SHINKAI_NODE_VERSION="v0.7.28" \
 npx ts-node ./ci-scripts/download-side-binaries.ts
 ```
 
@@ -55,14 +55,14 @@ npx ts-node ./ci-scripts/download-side-binaries.ts
 ```
 ARCH="x86_64-unknown-linux-gnu" \
 OLLAMA_VERSION="v0.3.1"\
-SHINKAI_NODE_VERSION="v0.7.27" \
+SHINKAI_NODE_VERSION="v0.7.28" \
 npx ts-node ./ci-scripts/download-side-binaries.ts
 ```
 
 #### Windows
 ```
 $ENV:OLLAMA_VERSION="v0.3.1"
-$ENV:SHINKAI_NODE_VERSION="v0.7.27"
+$ENV:SHINKAI_NODE_VERSION="v0.7.28"
 $ENV:ARCH="x86_64-pc-windows-msvc"
 npx ts-node ./ci-scripts/download-side-binaries.ts
 ```

--- a/apps/shinkai-desktop/src-tauri/src/local_shinkai_node/process_handlers/process_utils.rs
+++ b/apps/shinkai-desktop/src-tauri/src/local_shinkai_node/process_handlers/process_utils.rs
@@ -8,8 +8,9 @@ pub fn options_to_env<T: serde::Serialize>(options: &T) -> HashMap<String, Strin
     let options_reflection = serde_json::to_value(options).unwrap();
     for (key, value) in options_reflection.as_object().unwrap() {
         let env_key = key.to_uppercase();
-        let env_value = value.as_str().unwrap_or_default().to_string();
-        env.insert(env_key, env_value);
+        if let Some(env_value) = value.as_str() {
+            env.insert(env_key, env_value.to_string());
+        }
     }
     env
 }

--- a/apps/shinkai-desktop/src-tauri/src/local_shinkai_node/process_handlers/shinkai_node_process_handler.rs
+++ b/apps/shinkai-desktop/src-tauri/src/local_shinkai_node/process_handlers/shinkai_node_process_handler.rs
@@ -100,6 +100,18 @@ impl ShinkaiNodeProcessHandler {
                 fs::remove_dir_all(path).map_err(|e| format!("Failed to remove directory: {}", e))?;
             } else {
                 if preserve_keys && path.ends_with(".secret") {
+                    // Delete the line starting with 'GLOBAL_IDENTITY_NAME=' in .secret file
+                    if path.file_name().unwrap() == ".secret" {
+                        let content = fs::read_to_string(&path)
+                            .map_err(|e| format!("Failed to read .secret file: {}", e))?;
+                        let new_content: String = content
+                            .lines()
+                            .filter(|line| !line.starts_with("GLOBAL_IDENTITY_NAME="))
+                            .collect::<Vec<&str>>()
+                            .join("\n");
+                        fs::write(&path, new_content)
+                            .map_err(|e| format!("Failed to write updated .secret file: {}", e))?;
+                    }
                     continue;
                 }
                 fs::remove_file(path).map_err(|e| format!("Failed to remove file: {}", e))?;

--- a/apps/shinkai-desktop/src/components/reset-storage-before-connect-confirmation-prompt.tsx
+++ b/apps/shinkai-desktop/src/components/reset-storage-before-connect-confirmation-prompt.tsx
@@ -16,10 +16,10 @@ import {
   useShinkaiNodeRemoveStorageMutation,
   useShinkaiNodeSpawnMutation,
 } from '../lib/shinkai-node-manager/shinkai-node-manager-client';
+import { useShinkaiNodeManager } from '../store/shinkai-node-manager';
 
 export const ResetStorageBeforeConnectConfirmationPrompt = ({
   onCancel,
-  onRestore,
   onReset,
   ...props
 }: {
@@ -29,7 +29,7 @@ export const ResetStorageBeforeConnectConfirmationPrompt = ({
 } & AlertDialogProps) => {
   // const navigate = useNavigate();
   const { t } = useTranslation();
-
+  const { setShinkaiNodeOptions } = useShinkaiNodeManager();
   const { mutateAsync: shinkaiNodeKill } = useShinkaiNodeKillMutation();
   const { mutateAsync: shinkaiNodeSpawn } = useShinkaiNodeSpawnMutation();
   const { mutateAsync: shinkaiNodeRemoveStorage } =
@@ -51,6 +51,7 @@ export const ResetStorageBeforeConnectConfirmationPrompt = ({
   const reset = async (preserveKeys: boolean) => {
     await shinkaiNodeKill();
     await shinkaiNodeRemoveStorage({ preserveKeys });
+    setShinkaiNodeOptions(null);
     await shinkaiNodeSpawn();
     if (typeof onReset === 'function') {
       onReset();

--- a/apps/shinkai-desktop/src/lib/shinkai-node-manager/shinkai-node-manager-client.ts
+++ b/apps/shinkai-desktop/src/lib/shinkai-node-manager/shinkai-node-manager-client.ts
@@ -124,9 +124,10 @@ export const useShinkaiNodeRemoveStorageMutation = (
   >,
 ) => {
   const response = useMutation({
-    mutationFn: (
+    mutationFn: async (
       options: Partial<ShinkaiNodeRemoveStorageOptions>,
     ): Promise<void> => {
+      await invoke('shinkai_node_set_default_options');
       return invoke('shinkai_node_remove_storage', {
         preserveKeys: options?.preserveKeys,
       });

--- a/apps/shinkai-desktop/src/store/settings.ts
+++ b/apps/shinkai-desktop/src/store/settings.ts
@@ -2,6 +2,8 @@ import { LocaleMode, switchLanguage } from '@shinkai_network/shinkai-i18n';
 import { create } from 'zustand';
 import { devtools, persist } from 'zustand/middleware';
 
+import { SetupData, useAuth } from './auth';
+
 type SettingsStore = {
   defaultAgentId: string;
   setDefaultAgentId: (defaultAgentId: string) => void;
@@ -76,3 +78,15 @@ export const useSettings = create<SettingsStore>()(
     ),
   ),
 );
+
+useAuth.subscribe((state, prevState) => {
+  handleAuthSideEffect(state.auth, prevState.auth);
+});
+
+const handleAuthSideEffect = async (auth: SetupData | null, prevAuth: SetupData | null) => {
+  // SignOut case
+  if (prevAuth && !auth) {
+    useSettings.getState().setDefaultAgentId('');
+    return;
+  }
+};

--- a/apps/shinkai-desktop/src/store/shinkai-node-manager.ts
+++ b/apps/shinkai-desktop/src/store/shinkai-node-manager.ts
@@ -11,7 +11,7 @@ type ShinkaiNodeManagerStore = {
   setIsInUse: (value: boolean) => void;
   shinkaiNodeOptions: Partial<ShinkaiNodeOptions> | null;
   setShinkaiNodeOptions: (
-    shinkaiNodeOptions: Partial<ShinkaiNodeOptions>,
+    shinkaiNodeOptions: Partial<ShinkaiNodeOptions> | null,
   ) => void;
 };
 

--- a/apps/shinkai-desktop/src/windows/shinkai-node-manager/main.tsx
+++ b/apps/shinkai-desktop/src/windows/shinkai-node-manager/main.tsx
@@ -125,8 +125,9 @@ const App = () => {
     isPending: shinkaiNodeRemoveStorageIsPending,
     mutateAsync: shinkaiNodeRemoveStorage,
   } = useShinkaiNodeRemoveStorageMutation({
-    onSuccess: () => {
+    onSuccess: async () => {
       successRemovingShinkaiNodeStorageToast();
+      setShinkaiNodeOptions(null);
       setLogout();
     },
     onError: () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@shinkai/source",
-  "version": "0.7.28",
+  "version": "0.7.29",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@shinkai/source",
-      "version": "0.7.28",
+      "version": "0.7.29",
       "hasInstallScript": true,
       "license": "SEE LICENSE IN LICENSE",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shinkai/source",
-  "version": "0.7.28",
+  "version": "0.7.29",
   "license": "SEE LICENSE IN LICENSE",
   "files": [
     "LICENSE"


### PR DESCRIPTION
- When reset storage, shinkai-node options are cleared
- When reset storage, GLOBAL_IDENTITY_NAME is removed from .secret file
- When disconnect: defaultAgenId is removed from local storage
- When spawn Shinkai Node, just ENVs !== None are passed to the process
- bump Shinkai Node to v0.7.28
- bump Shinkai Desktop to v0.7.29