### PR TITLE
- refactor: bump shinkai-node to v0.8.14 for deno integration

### DIFF
--- a/.github/workflows/pr-ci-healchecks.yml
+++ b/.github/workflows/pr-ci-healchecks.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Download side binaries
         env:
           ARCH: x86_64-unknown-linux-gnu
-          SHINKAI_NODE_VERSION: v0.8.13
+          SHINKAI_NODE_VERSION: v0.8.14
           OLLAMA_VERSION: v0.3.14
         run: |
           npx ts-node ./ci-scripts/download-side-binaries.ts

--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -208,7 +208,7 @@ jobs:
       - name: Download side binaries
         env:
           ARCH: ${{ matrix.arch }}
-          SHINKAI_NODE_VERSION: v0.8.13
+          SHINKAI_NODE_VERSION: v0.8.14
           OLLAMA_VERSION: v0.3.14
         run: |
           npx ts-node ./ci-scripts/download-side-binaries.ts

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -206,7 +206,7 @@ jobs:
       - name: Download side binaries
         env:
           ARCH: ${{ matrix.arch }}
-          SHINKAI_NODE_VERSION: v0.8.13
+          SHINKAI_NODE_VERSION: v0.8.14
           OLLAMA_VERSION: v0.3.14
         run: |
           npx ts-node ./ci-scripts/download-side-binaries.ts

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ $ git clone https://github.com/dcSpark/shinkai-apps
 ```
 ARCH="aarch64-apple-darwin" \
 OLLAMA_VERSION="v0.3.14" \
-SHINKAI_NODE_VERSION="v0.8.13" \
+SHINKAI_NODE_VERSION="v0.8.14" \
 npx ts-node ./ci-scripts/download-side-binaries.ts
 ```
 
@@ -54,14 +54,14 @@ npx ts-node ./ci-scripts/download-side-binaries.ts
 ```
 ARCH="x86_64-unknown-linux-gnu" \
 OLLAMA_VERSION="v0.3.14"\
-SHINKAI_NODE_VERSION="v0.8.13" \
+SHINKAI_NODE_VERSION="v0.8.14" \
 npx ts-node ./ci-scripts/download-side-binaries.ts
 ```
 
 #### Windows
 ```
 $ENV:OLLAMA_VERSION="v0.3.14"
-$ENV:SHINKAI_NODE_VERSION="v0.8.13"
+$ENV:SHINKAI_NODE_VERSION="v0.8.14"
 $ENV:ARCH="x86_64-pc-windows-msvc"
 npx ts-node ./ci-scripts/download-side-binaries.ts
 ```

--- a/apps/shinkai-desktop/src-tauri/entitlements.plist
+++ b/apps/shinkai-desktop/src-tauri/entitlements.plist
@@ -16,7 +16,7 @@
     <key>com.apple.security.device.usb</key><true/>
     <key>com.apple.security.personal-information.location</key><true/>
 
-    <!-- entitlements required by shinkai-tools-backend (collected from nodejs entitlements) -->
+    <!-- entitlements required by deno (collected from nodejs entitlements) -->
     <key>com.apple.security.cs.allow-jit</key>
     <true/>
     <key>com.apple.security.cs.allow-unsigned-executable-memory</key>

--- a/apps/shinkai-desktop/src-tauri/src/local_shinkai_node/process_handlers/shinkai_node_process_handler.rs
+++ b/apps/shinkai-desktop/src-tauri/src/local_shinkai_node/process_handlers/shinkai_node_process_handler.rs
@@ -175,7 +175,6 @@ impl ShinkaiNodeProcessHandler {
             self.options.node_port.as_deref(),
             self.options.node_ws_port.as_deref(),
             self.options.node_api_port.as_deref(),
-            self.options.shinkai_tools_backend_api_port.as_deref(),
         ]
         .into_iter()
         .flatten()

--- a/apps/shinkai-desktop/src-tauri/src/local_shinkai_node/shinkai_node_options.rs
+++ b/apps/shinkai-desktop/src-tauri/src/local_shinkai_node/shinkai_node_options.rs
@@ -27,8 +27,7 @@ pub struct ShinkaiNodeOptions {
     pub rpc_url: Option<String>,
     pub default_embedding_model: Option<String>,
     pub supported_embedding_models: Option<String>,
-    pub shinkai_tools_backend_binary_path: Option<String>,
-    pub shinkai_tools_backend_api_port: Option<String>,
+    pub shinkai_tools_runner_deno_binary_path: Option<String>,
     pub pdfium_dynamic_lib_path: Option<String>,
 }
 
@@ -190,16 +189,10 @@ impl ShinkaiNodeOptions {
                     .or(base_options.supported_embedding_models)
                     .unwrap_or_default(),
             ),
-            shinkai_tools_backend_binary_path: Some(
+            shinkai_tools_runner_deno_binary_path: Some(
                 options
-                    .shinkai_tools_backend_binary_path
-                    .or(base_options.shinkai_tools_backend_binary_path)
-                    .unwrap_or_default(),
-            ),
-            shinkai_tools_backend_api_port: Some(
-                options
-                    .shinkai_tools_backend_api_port
-                    .or(base_options.shinkai_tools_backend_api_port)
+                    .shinkai_tools_runner_deno_binary_path
+                    .or(base_options.shinkai_tools_runner_deno_binary_path)
                     .unwrap_or_default(),
             ),
             pdfium_dynamic_lib_path: Some(match options.pdfium_dynamic_lib_path {
@@ -218,14 +211,14 @@ impl Default for ShinkaiNodeOptions {
         );
         let initial_agent_models = format!("ollama:{}", initial_model);
 
-        let shinkai_tools_backend_binary_path = std::env::current_exe()
+        let shinkai_tools_runner_deno_binary_path = std::env::current_exe()
             .unwrap()
             .parent()
             .unwrap()
             .join(if cfg!(target_os = "windows") {
-                "shinkai-tools-backend.exe"
+                "deno.exe"
             } else {
-                "shinkai-tools-backend"
+                "deno"
             })
             .to_string_lossy()
             .to_string();
@@ -252,8 +245,7 @@ impl Default for ShinkaiNodeOptions {
             rpc_url: Some("https://arbitrum-sepolia.blockpi.network/v1/rpc/public".to_string()),
             default_embedding_model: Some("snowflake-arctic-embed:xs".to_string()),
             supported_embedding_models: Some("snowflake-arctic-embed:xs".to_string()),
-            shinkai_tools_backend_binary_path: Some(shinkai_tools_backend_binary_path),
-            shinkai_tools_backend_api_port: Some("9650".to_string()),
+            shinkai_tools_runner_deno_binary_path: Some(shinkai_tools_runner_deno_binary_path),
             pdfium_dynamic_lib_path: None,
         }
     }

--- a/apps/shinkai-desktop/src-tauri/src/main.rs
+++ b/apps/shinkai-desktop/src-tauri/src/main.rs
@@ -41,11 +41,7 @@ struct Payload {
 
 fn main() {
     tauri::Builder::default()
-        .plugin(
-            tauri_plugin_log::Builder::new()
-                .level(log::LevelFilter::Info)
-                .build(),
-        )
+        .plugin(tauri_plugin_log::Builder::new().build())
         .plugin(tauri_plugin_os::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_shell::init())

--- a/apps/shinkai-desktop/src-tauri/tauri.conf.json
+++ b/apps/shinkai-desktop/src-tauri/tauri.conf.json
@@ -10,7 +10,7 @@
     "targets": ["app", "appimage", "nsis", "dmg"],
     "externalBin": [
       "external-binaries/shinkai-node/shinkai-node",
-      "external-binaries/shinkai-node/shinkai-tools-runner-resources/shinkai-tools-backend",
+      "external-binaries/shinkai-node/shinkai-tools-runner-resources/deno",
       "external-binaries/ollama/ollama"
     ],
     "icon": [

--- a/ci-scripts/download-side-binaries.ts
+++ b/ci-scripts/download-side-binaries.ts
@@ -104,21 +104,21 @@ const downloadShinkaiNodeBinary = async (arch: Arch, version: string) => {
     arch,
     `./apps/shinkai-desktop/src-tauri/external-binaries/shinkai-node/shinkai-node`,
   );
-  const shinkaiToolsBackendBinaryPath = asBinaryName(
+  const shinkaiToolsRunnerDenoBinaryPath = asBinaryName(
     arch,
-    `./apps/shinkai-desktop/src-tauri/external-binaries/shinkai-node/shinkai-tools-runner-resources/shinkai-tools-backend`,
+    `./apps/shinkai-desktop/src-tauri/external-binaries/shinkai-node/shinkai-tools-runner-resources/deno`,
   );
   await rename(
     shinkaiNodeBinaryPath,
     asSidecarName(arch, shinkaiNodeBinaryPath),
   );
   await rename(
-    shinkaiToolsBackendBinaryPath,
-    asSidecarName(arch, shinkaiToolsBackendBinaryPath),
+    shinkaiToolsRunnerDenoBinaryPath,
+    asSidecarName(arch, shinkaiToolsRunnerDenoBinaryPath),
   );
 
   await addExecPermissions(asSidecarName(arch, shinkaiNodeBinaryPath));
-  await addExecPermissions(asSidecarName(arch, shinkaiToolsBackendBinaryPath));
+  await addExecPermissions(asSidecarName(arch, shinkaiToolsRunnerDenoBinaryPath));
 };
 
 const downloadOllamaAarch64AppleDarwin = async (version: string) => {


### PR DESCRIPTION
- bump shinkai node to v0.8.14
- fixed CI and build scripts to works with the new deno binary
