### PR TITLE
- fix: ollama version empty when client and server version are equal

### DIFF
--- a/.github/workflows/pr-ci-healchecks.yml
+++ b/.github/workflows/pr-ci-healchecks.yml
@@ -38,7 +38,7 @@ jobs:
         env:
           ARCH: x86_64-unknown-linux-gnu
           SHINKAI_NODE_VERSION: v0.8.14
-          OLLAMA_VERSION: v0.4.0
+          OLLAMA_VERSION: v0.4.1
         run: |
           npx ts-node ./ci-scripts/download-side-binaries.ts
 

--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -209,7 +209,7 @@ jobs:
         env:
           ARCH: ${{ matrix.arch }}
           SHINKAI_NODE_VERSION: v0.8.14
-          OLLAMA_VERSION: v0.4.0
+          OLLAMA_VERSION: v0.4.1
         run: |
           npx ts-node ./ci-scripts/download-side-binaries.ts
 

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -207,7 +207,7 @@ jobs:
         env:
           ARCH: ${{ matrix.arch }}
           SHINKAI_NODE_VERSION: v0.8.14
-          OLLAMA_VERSION: v0.4.0
+          OLLAMA_VERSION: v0.4.1
         run: |
           npx ts-node ./ci-scripts/download-side-binaries.ts
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ $ git clone https://github.com/dcSpark/shinkai-apps
 #### Macos
 ```
 ARCH="aarch64-apple-darwin" \
-OLLAMA_VERSION="v0.4.0" \
+OLLAMA_VERSION="v0.4.1" \
 SHINKAI_NODE_VERSION="v0.8.14" \
 npx ts-node ./ci-scripts/download-side-binaries.ts
 ```
@@ -53,14 +53,14 @@ npx ts-node ./ci-scripts/download-side-binaries.ts
 #### Linux
 ```
 ARCH="x86_64-unknown-linux-gnu" \
-OLLAMA_VERSION="v0.4.0"\
+OLLAMA_VERSION="v0.4.1"\
 SHINKAI_NODE_VERSION="v0.8.14" \
 npx ts-node ./ci-scripts/download-side-binaries.ts
 ```
 
 #### Windows
 ```
-$ENV:OLLAMA_VERSION="v0.4.0"
+$ENV:OLLAMA_VERSION="v0.4.1"
 $ENV:SHINKAI_NODE_VERSION="v0.8.14"
 $ENV:ARCH="x86_64-pc-windows-msvc"
 npx ts-node ./ci-scripts/download-side-binaries.ts

--- a/ci-scripts/download-side-binaries.ts
+++ b/ci-scripts/download-side-binaries.ts
@@ -1,5 +1,5 @@
 import { exec } from 'child_process';
-import { createWriteStream, existsSync } from 'fs';
+import { createWriteStream } from 'fs';
 import path from 'path';
 import axios from 'axios';
 import { ensureFile } from 'fs-extra';
@@ -46,9 +46,6 @@ const addExecPermissions = (path: string) => {
 };
 
 const downloadFile = async (url: string, path: string): Promise<void> => {
-  if (existsSync(path)) {
-    return Promise.resolve();
-  }
   console.log(`Downloading ${url}`);
   const response = await axios({
     method: 'GET',


### PR DESCRIPTION
To fetch the embedded ollama version we spawn `ollama -v` and capture the output to grab the version value.

'client version is *.*.*' contains the real ollama version our app is running (embedded) BUT
- when embedded and local ollama are equal the message says 'ollama version is *.*.*'
- when embedded and local are different, the message says 'ollama version is *.*.*... \nWarning client version is *.*.*'

So we try to find the client version and if it doesn't exists we fallback to ollama version (that means client and local are equals)