### PR TITLE
Improve syncFileToIDBFS test coverage

### DIFF
--- a/apps/shinkai-desktop/src/components/chat/python-code-runner/services/__tests__/job-service.test.ts
+++ b/apps/shinkai-desktop/src/components/chat/python-code-runner/services/__tests__/job-service.test.ts
@@ -221,6 +221,28 @@ describe('JobService', () => {
       );
     });
 
+    it('should sync file with nested path correctly', async () => {
+      mockDownloadFile.mockResolvedValue('nested content');
+
+      await jobService.syncFileToIDBFS({
+        path: 'subdir/test.txt',
+        name: 'test.txt',
+      });
+
+      expect(mockDownloadFile).toHaveBeenCalledWith({
+        nodeAddress: 'test-node',
+        token: 'test-token',
+        path: 'subdir/test.txt',
+      });
+      expect(mockFileSystemService.ensureDirectory).toHaveBeenCalledWith(
+        '/home/pyodide/subdir'
+      );
+      expect(mockFileSystemService.writeFile).toHaveBeenCalledWith(
+        '/home/pyodide/subdir/test.txt',
+        'nested content'
+      );
+    });
+
     it('should handle download errors', async () => {
       mockDownloadFile.mockRejectedValue(new Error('Download failed'));
 

--- a/apps/shinkai-desktop/src/components/chat/python-code-runner/services/job-service.ts
+++ b/apps/shinkai-desktop/src/components/chat/python-code-runner/services/job-service.ts
@@ -165,10 +165,14 @@ export class JobService implements IJobService {
         path: item.path,
       });
 
-      this.fileSystemService.writeFile(`/home/pyodide/${item.name}`, content);
-      console.log(`Synced file ${item.name} to IDBFS`);
+      const targetPath = `/home/pyodide/${item.path}`;
+      const dirOnly = targetPath.substring(0, targetPath.lastIndexOf('/'));
+      this.fileSystemService.ensureDirectory(dirOnly);
+
+      this.fileSystemService.writeFile(targetPath, content);
+      console.log(`Synced file ${item.path} to IDBFS`);
     } catch (error) {
-      console.error(`Failed to sync file ${item.name}:`, error);
+      console.error(`Failed to sync file ${item.path}:`, error);
       throw error;
     }
   }


### PR DESCRIPTION
## Summary
- add test for nested paths in `syncFileToIDBFS`
- create directories and write using the full file path

## Testing
- `npx jest --config apps/shinkai-desktop/jest.config.ts apps/shinkai-desktop/src/components/chat/python-code-runner/services/__tests__/job-service.test.ts --runInBand`