### PR TITLE
Bundle WebKit on Linux

### DIFF
--- a/apps/shinkai-desktop/src-tauri/tauri.linux.conf.json
+++ b/apps/shinkai-desktop/src-tauri/tauri.linux.conf.json
@@ -2,7 +2,7 @@
   "bundle": {
     "linux": {
       "appimage": {
-        "bundleMediaFramework": false
+        "bundleMediaFramework": true
       }
     }
   }


### PR DESCRIPTION
## Summary
- ensure Tauri bundles WebKit for AppImage builds

## Testing
- `npx nx run-many -t lint,test --parallel=3 --skip-nx-cache --verbose --exclude=shinkai-desktop,shinkai-visor`
