### PR TITLE
fix: ollama tags type to prevent initialization errors

### DIFF
--- a/apps/shinkai-desktop/src-tauri/src/local_shinkai_node/ollama_api/ollama_api_types.rs
+++ b/apps/shinkai-desktop/src-tauri/src/local_shinkai_node/ollama_api/ollama_api_types.rs
@@ -15,7 +15,7 @@ pub struct ModelDetails {
     pub parent_model: String,
     pub format: String,
     pub family: String,
-    pub families: Vec<String>,
+    pub families: Option<Vec<String>>,
     pub parameter_size: String,
     pub quantization_level: String,
 }


### PR DESCRIPTION
- fix: ollama tags type to prevent parse errors when call /api/tags 
- improve: initialization flow now try to re install embeddings model if couldn't fetch/found tags. So the initialization still works
