### PR TITLE
Add MCP badge in tool list

### DIFF
--- a/apps/shinkai-desktop/src/components/tools/components/tool-card.tsx
+++ b/apps/shinkai-desktop/src/components/tools/components/tool-card.tsx
@@ -68,6 +68,11 @@ export default function ToolCard({ tool }: { tool: ShinkaiToolHeader }) {
           <Badge className="text-gray-80 bg-official-gray-750 text-xs font-normal">
             {getVersionFromTool(tool)}
           </Badge>
+          {tool.tool_type === 'MCPServer' && (
+            <Badge className="text-gray-80 bg-official-gray-750 text-xs font-normal">
+              MCP
+            </Badge>
+          )}
           {tool.author !== '@@official.shinkai' && (
             <Badge className="text-gray-80 bg-official-gray-750 text-xs font-normal">
               {tool.author}


### PR DESCRIPTION
## Summary
- display an `MCP` badge in the tool list when a tool is of type `MCPServer`

## Testing
- `npx nx lint shinkai-desktop` *(fails: failed to fetch crate due to lack of network)*
- `git status --short`
