### PR TITLE
Add MCP discovery dropdown

### DIFF
--- a/apps/shinkai-desktop/src/components/mcp-servers/mcp-servers.tsx
+++ b/apps/shinkai-desktop/src/components/mcp-servers/mcp-servers.tsx
@@ -91,26 +91,47 @@ export const McpServers = () => {
             value={searchQuery}
           />
 
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button className="min-w-[100px]" size="md">
-                <Plus className="h-4 w-4" />
-                <span>Add MCP Server</span>
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end" className="p-1.5 px-2">
-              <DropdownMenuItem
-                onClick={() => setIsAddMcpServerModalOpen(true)}
-              >
-                {t('mcpServers.manualSetup')}
-              </DropdownMenuItem>
-              <DropdownMenuItem
-                onClick={() => setIsAddMcpServerWithGithubModalOpen(true)}
-              >
-                Add from GitHub
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
+          <div className="flex gap-2">
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button className="min-w-[100px]" size="md">
+                  <Plus className="h-4 w-4" />
+                  <span>Add MCP Server</span>
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="p-1.5 px-2">
+                <DropdownMenuItem
+                  onClick={() => setIsAddMcpServerModalOpen(true)}
+                >
+                  {t('mcpServers.manualSetup')}
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  onClick={() => setIsAddMcpServerWithGithubModalOpen(true)}
+                >
+                  Add from GitHub
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button className="min-w-[100px]" size="md">
+                  <span>{t('mcpServers.find')}</span>
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="p-1.5 px-2">
+                <DropdownMenuItem
+                  onClick={() => window.open('http://smithery.ai', '_blank')}
+                >
+                  smithery.ai
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  onClick={() => window.open('http://composio.dev', '_blank')}
+                >
+                  composio.dev
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
         </div>
 
         {isLoading ? (

--- a/libs/shinkai-i18n/locales/en-US.json
+++ b/libs/shinkai-i18n/locales/en-US.json
@@ -602,6 +602,7 @@
     "updateFailed": "Failed to update MCP server",
     "manualSetup": "Manual Setup",
     "addFromGitHub": "Add from GitHub",
+    "find": "Find MCPs",
     "tools": "tools",
     "toolsFor": "Tools for {{name}}",
     "listOfToolsAvailableFromThisMcpServer": "List of tools available from this MCP server.",

--- a/libs/shinkai-i18n/src/lib/default/index.ts
+++ b/libs/shinkai-i18n/src/lib/default/index.ts
@@ -664,6 +664,7 @@ export default {
     updateFailed: 'Failed to update MCP server',
     manualSetup: 'Manual Setup',
     addFromGitHub: 'Add from GitHub',
+    find: 'Find MCPs',
     tools: 'tools',
     toolsFor: 'Tools for {{name}}',
     listOfToolsAvailableFromThisMcpServer:


### PR DESCRIPTION
## Summary
- add a "Find MCPs" dropdown to the MCP Servers page with links to smithery.ai and composio.dev
- localize new button label

## Testing
- `npx nx lint shinkai-desktop` *(fails: process crashes in this environment)*
- `npx nx test shinkai-desktop --skip-nx-cache` *(fails: process crashes in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_683bcfe103848321a1895d3b43d1928c