### PR TITLE
Add chat export messages option

### DIFF
--- a/apps/shinkai-desktop/src/components/chat/conversation-header.tsx
+++ b/apps/shinkai-desktop/src/components/chat/conversation-header.tsx
@@ -18,6 +18,10 @@ import {
   SheetHeader,
   SheetTitle,
   SheetTrigger,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
   Tooltip,
   TooltipContent,
   TooltipPortal,
@@ -37,7 +41,13 @@ import {
   FolderIcon,
   PanelRightClose,
   PanelRightOpen,
+  DownloadIcon,
 } from 'lucide-react';
+import { DotsVerticalIcon } from '@radix-ui/react-icons';
+import { save } from '@tauri-apps/plugin-dialog';
+import * as fs from '@tauri-apps/plugin-fs';
+import { BaseDirectory } from '@tauri-apps/plugin-fs';
+import { useExportMessagesFromInbox } from '@shinkai_network/shinkai-node-state/v2/mutations/exportMessagesFromInbox/useExportMessagesFromInbox';
 import { memo } from 'react';
 import { Link, useParams } from 'react-router';
 
@@ -45,6 +55,14 @@ import { useGetCurrentInbox } from '../../hooks/use-current-inbox';
 import { useAuth } from '../../store/auth';
 import { useSettings } from '../../store/settings';
 import ProviderIcon from '../ais/provider-icon';
+import { toast } from 'sonner';
+
+function sanitizeFileName(name: string): string {
+  let sanitized = name.replace(/[^a-zA-Z0-9_]/g, '_');
+  sanitized = sanitized.replace(/_+/g, '_');
+  sanitized = sanitized.replace(/^_+|_+$/g, '');
+  return sanitized || 'chat';
+}
 
 const ConversationHeaderWithInboxId = () => {
   const currentInbox = useGetCurrentInbox();
@@ -86,9 +104,43 @@ const ConversationHeaderWithInboxId = () => {
     (provider) => provider.id === selectedAgent?.llm_provider_id,
   );
 
+  const { mutateAsync: exportMessages } = useExportMessagesFromInbox({
+    onSuccess: async (response) => {
+      const sanitizedName = sanitizeFileName(
+        currentInbox?.custom_name || inboxId,
+      );
+      const file = new Blob([response ?? ''], {
+        type: 'application/octet-stream',
+      });
+      const arrayBuffer = await file.arrayBuffer();
+      const content = new Uint8Array(arrayBuffer);
+
+      const savePath = await save({
+        defaultPath: `${sanitizedName}.json`,
+        filters: [{ name: 'JSON File', extensions: ['json'] }],
+      });
+
+      if (!savePath) {
+        toast.info('File saving cancelled');
+        return;
+      }
+
+      await fs.writeFile(savePath, content, {
+        baseDir: BaseDirectory.Download,
+      });
+
+      toast.success('Chat exported successfully');
+    },
+    onError: (error) => {
+      toast.error('Failed to export chat', {
+        description: error.response?.data?.message ?? error.message,
+      });
+    },
+  });
+
   return (
     <div className="border-official-gray-780 flex h-[58px] items-center justify-between border-b px-4 py-2">
-      <div className="flex w-full items-center gap-2">
+      <div className="flex flex-1 items-center gap-2">
         <Tooltip>
           <TooltipTrigger asChild>
             <Button
@@ -404,6 +456,41 @@ const ConversationHeaderWithInboxId = () => {
             currentInbox?.custom_name || currentInbox?.inbox_id
           )}
         </div>
+      </div>
+      <div className="flex items-center gap-2">
+        <DropdownMenu modal={false}>
+          <DropdownMenuTrigger asChild>
+            <div
+              className={cn(
+                buttonVariants({ variant: 'tertiary', size: 'icon' }),
+                'border-0 hover:bg-gray-500/40',
+              )}
+              onClick={(e) => e.stopPropagation()}
+              role="button"
+              tabIndex={0}
+            >
+              <span className="sr-only">{t('common.moreOptions')}</span>
+              <DotsVerticalIcon className="text-gray-100" />
+            </div>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent
+            align="end"
+            className="w-[160px] border bg-gray-500 px-2.5 py-2"
+          >
+            <DropdownMenuItem
+              onClick={async () => {
+                await exportMessages({
+                  inboxId,
+                  nodeAddress: auth?.node_address ?? '',
+                  token: auth?.api_v2_key ?? '',
+                });
+              }}
+            >
+              <DownloadIcon className="mr-3 h-4 w-4" />
+              Export Messages
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
       </div>
     </div>
   );

--- a/libs/shinkai-message-ts/src/api/jobs/index.ts
+++ b/libs/shinkai-message-ts/src/api/jobs/index.ts
@@ -581,3 +581,19 @@ export const forkJobMessages = async (
   );
   return response.data as ForkJobMessagesResponse;
 };
+
+export const exportMessagesFromInbox = async (
+  nodeAddress: string,
+  bearerToken: string,
+  inboxId: string,
+) => {
+  const response = await httpClient.get(
+    urlJoin(nodeAddress, '/v2/export_messages_from_inbox'),
+    {
+      headers: { Authorization: `Bearer ${bearerToken}` },
+      params: { inbox_id: inboxId },
+      responseType: 'blob',
+    },
+  );
+  return response.data as Blob;
+};

--- a/libs/shinkai-node-state/src/v2/mutations/exportMessagesFromInbox/index.ts
+++ b/libs/shinkai-node-state/src/v2/mutations/exportMessagesFromInbox/index.ts
@@ -1,0 +1,11 @@
+import { exportMessagesFromInbox as exportMessagesFromInboxApi } from '@shinkai_network/shinkai-message-ts/api/jobs/index';
+
+import { type ExportMessagesFromInboxInput } from './types';
+
+export const exportMessagesFromInbox = async ({
+  nodeAddress,
+  token,
+  inboxId,
+}: ExportMessagesFromInboxInput) => {
+  return await exportMessagesFromInboxApi(nodeAddress, token, inboxId);
+};

--- a/libs/shinkai-node-state/src/v2/mutations/exportMessagesFromInbox/types.ts
+++ b/libs/shinkai-node-state/src/v2/mutations/exportMessagesFromInbox/types.ts
@@ -1,0 +1,8 @@
+import { type Token } from '@shinkai_network/shinkai-message-ts/api/general/types';
+
+export type ExportMessagesFromInboxInput = Token & {
+  nodeAddress: string;
+  inboxId: string;
+};
+
+export type ExportMessagesFromInboxOutput = Blob;

--- a/libs/shinkai-node-state/src/v2/mutations/exportMessagesFromInbox/useExportMessagesFromInbox.ts
+++ b/libs/shinkai-node-state/src/v2/mutations/exportMessagesFromInbox/useExportMessagesFromInbox.ts
@@ -1,0 +1,21 @@
+import { useMutation, type UseMutationOptions } from '@tanstack/react-query';
+
+import { type APIError } from '../../types';
+import {
+  type ExportMessagesFromInboxInput,
+  type ExportMessagesFromInboxOutput,
+} from './types';
+import { exportMessagesFromInbox } from '.';
+
+type Options = UseMutationOptions<
+  ExportMessagesFromInboxOutput,
+  APIError,
+  ExportMessagesFromInboxInput
+>;
+
+export const useExportMessagesFromInbox = (options?: Options) => {
+  return useMutation({
+    mutationFn: exportMessagesFromInbox,
+    ...options,
+  });
+};


### PR DESCRIPTION
## Summary
- add export messages API
- expose export messages mutation
- add export dropdown menu in conversation header
- fix missing dropdown import for export menu

## Testing
- `npx nx lint shinkai-desktop` *(fails: The terminal crashed during linting)*
- `npx nx test shinkai-desktop --skip-nx-cache --output-style=stream`


------
https://chatgpt.com/codex/tasks/task_e_683bce6814dc8321b0b04ba898f82571