### PR TITLE
Add chat export messages option

### DIFF
--- a/libs/shinkai-message-ts/src/api/jobs/index.ts
+++ b/libs/shinkai-message-ts/src/api/jobs/index.ts
@@ -48,6 +48,7 @@ import {
   type UpdateLLMProviderInJobResponse,
   type UpdateLLMProviderRequest,
   type UpdateLLMProviderResponse,
+  type ExportInboxMessagesRequest,
 } from './types';
 
 export const createJob = async (
@@ -580,4 +581,23 @@ export const forkJobMessages = async (
     },
   );
   return response.data as ForkJobMessagesResponse;
+};
+
+export const exportMessagesFromInbox = async (
+  nodeAddress: string,
+  bearerToken: string,
+  payload: ExportInboxMessagesRequest,
+): Promise<Blob> => {
+  const response = await httpClient.post(
+    urlJoin(nodeAddress, '/v2/export_messages_from_inbox'),
+    {
+      inbox_name: payload.inbox_name,
+      format: payload.format,
+    },
+    {
+      headers: { Authorization: `Bearer ${bearerToken}` },
+      responseType: 'blob',
+    },
+  );
+  return response.data as Blob;
 };

--- a/libs/shinkai-message-ts/src/api/jobs/types.ts
+++ b/libs/shinkai-message-ts/src/api/jobs/types.ts
@@ -315,3 +315,16 @@ export type ForkJobMessagesRequest = {
 export type ForkJobMessagesResponse = {
   job_id: string;
 };
+
+export enum ExportInboxMessagesFormat {
+  CSV = 'CSV',
+  JSON = 'JSON',
+  TXT = 'TXT',
+}
+
+export type ExportInboxMessagesRequest = {
+  inbox_name: string;
+  format: ExportInboxMessagesFormat;
+};
+
+export type ExportInboxMessagesResponse = Blob;

--- a/libs/shinkai-node-state/src/v2/mutations/exportMessagesFromInbox/index.ts
+++ b/libs/shinkai-node-state/src/v2/mutations/exportMessagesFromInbox/index.ts
@@ -1,0 +1,15 @@
+import { exportMessagesFromInbox as exportMessagesFromInboxApi } from '@shinkai_network/shinkai-message-ts/api/jobs/index';
+
+import { type ExportMessagesFromInboxInput } from './types';
+
+export const exportMessagesFromInbox = async ({
+  nodeAddress,
+  token,
+  inbox_name,
+  format,
+}: ExportMessagesFromInboxInput) => {
+  return await exportMessagesFromInboxApi(nodeAddress, token, {
+    inbox_name,
+    format,
+  });
+};

--- a/libs/shinkai-node-state/src/v2/mutations/exportMessagesFromInbox/types.ts
+++ b/libs/shinkai-node-state/src/v2/mutations/exportMessagesFromInbox/types.ts
@@ -1,0 +1,12 @@
+import { type Token } from '@shinkai_network/shinkai-message-ts/api/general/types';
+
+import {
+  type ExportInboxMessagesFormat,
+  type ExportInboxMessagesRequest,
+} from '@shinkai_network/shinkai-message-ts/api/jobs/types';
+
+export type ExportMessagesFromInboxInput = Token & {
+  nodeAddress: string;
+} & ExportInboxMessagesRequest;
+
+export type ExportMessagesFromInboxOutput = Blob;

--- a/libs/shinkai-node-state/src/v2/mutations/exportMessagesFromInbox/useExportMessagesFromInbox.ts
+++ b/libs/shinkai-node-state/src/v2/mutations/exportMessagesFromInbox/useExportMessagesFromInbox.ts
@@ -1,0 +1,21 @@
+import { useMutation, type UseMutationOptions } from '@tanstack/react-query';
+
+import { type APIError } from '../../types';
+import {
+  type ExportMessagesFromInboxInput,
+  type ExportMessagesFromInboxOutput,
+} from './types';
+import { exportMessagesFromInbox } from '.';
+
+type Options = UseMutationOptions<
+  ExportMessagesFromInboxOutput,
+  APIError,
+  ExportMessagesFromInboxInput
+>;
+
+export const useExportMessagesFromInbox = (options?: Options) => {
+  return useMutation({
+    mutationFn: exportMessagesFromInbox,
+    ...options,
+  });
+};


### PR DESCRIPTION
## Summary
- add export messages API
- expose export messages mutation
- add export dropdown menu in conversation header
- support choosing CSV, JSON or TXT

## Testing
- ❌ `npx nx run-many --target=lint --all --skip-nx-cache`
- ✅ `npx nx test shinkai-desktop --skip-nx-cache --output-style=stream`


------
https://chatgpt.com/codex/tasks/task_e_683bce6814dc8321b0b04ba898f82571