### PR TITLE
Add chat export messages option

### DIFF
--- a/apps/shinkai-desktop/src/components/chat/conversation-header.tsx
+++ b/apps/shinkai-desktop/src/components/chat/conversation-header.tsx
@@ -22,6 +22,10 @@ import {
   TooltipContent,
   TooltipPortal,
   TooltipTrigger,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
 } from '@shinkai_network/shinkai-ui';
 import {
   AgentIcon,
@@ -37,7 +41,13 @@ import {
   FolderIcon,
   PanelRightClose,
   PanelRightOpen,
+  DownloadIcon,
 } from 'lucide-react';
+import { DotsVerticalIcon } from '@radix-ui/react-icons';
+import { save } from '@tauri-apps/plugin-dialog';
+import * as fs from '@tauri-apps/plugin-fs';
+import { BaseDirectory } from '@tauri-apps/plugin-fs';
+import { useExportMessagesFromInbox } from '@shinkai_network/shinkai-node-state/v2/mutations/exportMessagesFromInbox/useExportMessagesFromInbox';
 import { memo } from 'react';
 import { Link, useParams } from 'react-router';
 
@@ -45,6 +55,14 @@ import { useGetCurrentInbox } from '../../hooks/use-current-inbox';
 import { useAuth } from '../../store/auth';
 import { useSettings } from '../../store/settings';
 import ProviderIcon from '../ais/provider-icon';
+import { toast } from 'sonner';
+
+function sanitizeFileName(name: string): string {
+  let sanitized = name.replace(/[^a-zA-Z0-9_]/g, '_');
+  sanitized = sanitized.replace(/_+/g, '_');
+  sanitized = sanitized.replace(/^_+|_+$/g, '');
+  return sanitized || 'chat';
+}
 
 const ConversationHeaderWithInboxId = () => {
   const currentInbox = useGetCurrentInbox();
@@ -86,9 +104,44 @@ const ConversationHeaderWithInboxId = () => {
     (provider) => provider.id === selectedAgent?.llm_provider_id,
   );
 
+  const { mutateAsync: exportMessages } = useExportMessagesFromInbox({
+    onSuccess: async (response, variables) => {
+      const sanitizedName = sanitizeFileName(
+        currentInbox?.custom_name || inboxId,
+      );
+      const extension = variables.format;
+      const file = new Blob([response ?? ''], {
+        type: 'application/octet-stream',
+      });
+      const arrayBuffer = await file.arrayBuffer();
+      const content = new Uint8Array(arrayBuffer);
+
+      const savePath = await save({
+        defaultPath: `${sanitizedName}.${extension}`,
+        filters: [{ name: `${extension.toUpperCase()} File`, extensions: [extension] }],
+      });
+
+      if (!savePath) {
+        toast.info('File saving cancelled');
+        return;
+      }
+
+      await fs.writeFile(savePath, content, {
+        baseDir: BaseDirectory.Download,
+      });
+
+      toast.success('Chat exported successfully');
+    },
+    onError: (error) => {
+      toast.error('Failed to export chat', {
+        description: error.response?.data?.message ?? error.message,
+      });
+    },
+  });
+
   return (
     <div className="border-official-gray-780 flex h-[58px] items-center justify-between border-b px-4 py-2">
-      <div className="flex w-full items-center gap-2">
+      <div className="flex flex-1 items-center gap-2">
         <Tooltip>
           <TooltipTrigger asChild>
             <Button
@@ -404,6 +457,68 @@ const ConversationHeaderWithInboxId = () => {
             currentInbox?.custom_name || currentInbox?.inbox_id
           )}
         </div>
+      </div>
+      <div className="flex items-center gap-2">
+        <DropdownMenu modal={false}>
+          <DropdownMenuTrigger asChild>
+            <div
+              className={cn(
+                buttonVariants({ variant: 'tertiary', size: 'icon' }),
+                'border-0 hover:bg-gray-500/40',
+              )}
+              onClick={(e) => e.stopPropagation()}
+              role="button"
+              tabIndex={0}
+            >
+              <span className="sr-only">{t('common.moreOptions')}</span>
+              <DotsVerticalIcon className="text-gray-100" />
+            </div>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent
+            align="end"
+            className="w-[200px] border bg-gray-500 px-2.5 py-2"
+          >
+            <DropdownMenuItem
+              onClick={async () => {
+                await exportMessages({
+                  inboxId,
+                  nodeAddress: auth?.node_address ?? '',
+                  token: auth?.api_v2_key ?? '',
+                  format: 'json',
+                });
+              }}
+            >
+              <DownloadIcon className="mr-3 h-4 w-4" />
+              Export as JSON
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              onClick={async () => {
+                await exportMessages({
+                  inboxId,
+                  nodeAddress: auth?.node_address ?? '',
+                  token: auth?.api_v2_key ?? '',
+                  format: 'csv',
+                });
+              }}
+            >
+              <DownloadIcon className="mr-3 h-4 w-4" />
+              Export as CSV
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              onClick={async () => {
+                await exportMessages({
+                  inboxId,
+                  nodeAddress: auth?.node_address ?? '',
+                  token: auth?.api_v2_key ?? '',
+                  format: 'txt',
+                });
+              }}
+            >
+              <DownloadIcon className="mr-3 h-4 w-4" />
+              Export as TXT
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
       </div>
     </div>
   );

--- a/libs/shinkai-message-ts/src/api/jobs/index.ts
+++ b/libs/shinkai-message-ts/src/api/jobs/index.ts
@@ -11,6 +11,8 @@ import {
   type CreateJobResponse,
   type ForkJobMessagesRequest,
   type ForkJobMessagesResponse,
+  type ExportMessagesFromInboxRequest,
+  type ExportMessagesFromInboxResponse,
   type GetAllAgentInboxesRequest,
   type GetAllInboxesResponse,
   type GetAllInboxesWithPaginationRequest,
@@ -580,4 +582,20 @@ export const forkJobMessages = async (
     },
   );
   return response.data as ForkJobMessagesResponse;
+};
+
+export const exportMessagesFromInbox = async (
+  nodeAddress: string,
+  bearerToken: string,
+  payload: ExportMessagesFromInboxRequest,
+) => {
+  const response = await httpClient.post(
+    urlJoin(nodeAddress, '/v2/export_messages_from_inbox'),
+    payload,
+    {
+      headers: { Authorization: `Bearer ${bearerToken}` },
+      responseType: 'blob',
+    },
+  );
+  return response.data as ExportMessagesFromInboxResponse;
 };

--- a/libs/shinkai-message-ts/src/api/jobs/types.ts
+++ b/libs/shinkai-message-ts/src/api/jobs/types.ts
@@ -315,3 +315,12 @@ export type ForkJobMessagesRequest = {
 export type ForkJobMessagesResponse = {
   job_id: string;
 };
+
+export type ExportInboxMessagesFormat = 'csv' | 'json' | 'txt';
+
+export type ExportMessagesFromInboxRequest = {
+  inbox_name: string;
+  format: ExportInboxMessagesFormat;
+};
+
+export type ExportMessagesFromInboxResponse = Blob;

--- a/libs/shinkai-node-state/src/v2/mutations/exportMessagesFromInbox/index.ts
+++ b/libs/shinkai-node-state/src/v2/mutations/exportMessagesFromInbox/index.ts
@@ -1,0 +1,15 @@
+import { exportMessagesFromInbox as exportMessagesFromInboxApi } from '@shinkai_network/shinkai-message-ts/api/jobs/index';
+
+import { type ExportMessagesFromInboxInput } from './types';
+
+export const exportMessagesFromInbox = async ({
+  nodeAddress,
+  token,
+  inboxId,
+  format,
+}: ExportMessagesFromInboxInput) => {
+  return await exportMessagesFromInboxApi(nodeAddress, token, {
+    inbox_name: inboxId,
+    format,
+  });
+};

--- a/libs/shinkai-node-state/src/v2/mutations/exportMessagesFromInbox/types.ts
+++ b/libs/shinkai-node-state/src/v2/mutations/exportMessagesFromInbox/types.ts
@@ -1,0 +1,9 @@
+import { type Token } from '@shinkai_network/shinkai-message-ts/api/general/types';
+
+export type ExportMessagesFromInboxInput = Token & {
+  nodeAddress: string;
+  inboxId: string;
+  format: 'csv' | 'json' | 'txt';
+};
+
+export type ExportMessagesFromInboxOutput = Blob;

--- a/libs/shinkai-node-state/src/v2/mutations/exportMessagesFromInbox/useExportMessagesFromInbox.ts
+++ b/libs/shinkai-node-state/src/v2/mutations/exportMessagesFromInbox/useExportMessagesFromInbox.ts
@@ -1,0 +1,21 @@
+import { useMutation, type UseMutationOptions } from '@tanstack/react-query';
+
+import { type APIError } from '../../types';
+import {
+  type ExportMessagesFromInboxInput,
+  type ExportMessagesFromInboxOutput,
+} from './types';
+import { exportMessagesFromInbox } from '.';
+
+type Options = UseMutationOptions<
+  ExportMessagesFromInboxOutput,
+  APIError,
+  ExportMessagesFromInboxInput
+>;
+
+export const useExportMessagesFromInbox = (options?: Options) => {
+  return useMutation({
+    mutationFn: exportMessagesFromInbox,
+    ...options,
+  });
+};


### PR DESCRIPTION
## Summary
- add export messages API
- expose export messages mutation
- add export dropdown menu in conversation header
- support exporting as JSON, CSV, or TXT
- widen the dropdown menu to 200px

## Testing
- `npx nx run-many --target=lint --all --skip-nx-cache --output-style=stream`
- `npx nx test shinkai-desktop --skip-nx-cache --output-style=stream`


------
https://chatgpt.com/codex/tasks/task_e_683bce6814dc8321b0b04ba898f82571