### PR TITLE
Enhance MCP tools dialog

### DIFF
--- a/apps/shinkai-desktop/src/components/mcp-servers/mcp-server-card.tsx
+++ b/apps/shinkai-desktop/src/components/mcp-servers/mcp-server-card.tsx
@@ -138,39 +138,44 @@ export const McpServerCard = ({
                   {t('mcpServers.viewAvailableTools')}
                 </TooltipContent>
               </Tooltip>
-              <DialogContent className="sm:max-w-xl" showCloseButton>
-                <DialogHeader>
-                  <DialogTitle>
+              <DialogContent
+                className="w-[580px] space-y-6 rounded-xl bg-official-gray-950 text-official-gray-100 shadow-xl"
+                showCloseButton
+              >
+                <DialogHeader className="p-0">
+                  <DialogTitle className="text-lg font-semibold">
                     {t('mcpServers.toolsFor', { name: server.name })}
                   </DialogTitle>
-                  <DialogDescription>
+                  <DialogDescription className="text-base text-official-gray-300">
                     {t('mcpServers.listOfToolsAvailableFromThisMcpServer')}
                   </DialogDescription>
                 </DialogHeader>
-                <div className="max-h-[60vh] overflow-y-auto py-1">
+                <div className="max-h-[60vh] overflow-y-auto">
                   {mcpServerTools && mcpServerTools.length > 0 ? (
-                    <ul className="space-y-3">
+                    <ul className="list-disc list-outside space-y-6 pl-5">
                       {mcpServerTools.map((tool) => (
                         <li
-                          className="border-official-gray-780 bg-official-gray-900 rounded-lg border p-3 py-2.5 text-sm"
+                          className="border-b border-official-gray-780 pb-4 last:border-none"
                           key={tool.id}
                         >
-                          <div>
+                          <div className="space-y-1">
                             {tool.tool_router_key ? (
                               <Link
                                 className="text-white hover:underline"
                                 onClick={() => setIsToolsDialogOpen(false)}
                                 to={`/tools/${tool.tool_router_key}`}
                               >
-                                {getToolDisplayName(tool.name)}
+                                <h3 className="text-base font-semibold">
+                                  {getToolDisplayName(tool.name)}
+                                </h3>
                               </Link>
                             ) : (
-                              <span className="text-white">
+                              <h3 className="text-base font-semibold text-white">
                                 {getToolDisplayName(tool.name)}
-                              </span>
+                              </h3>
                             )}
                             {tool.description && (
-                              <p className="text-official-gray-400 text-sm whitespace-pre-wrap">
+                              <p className="text-official-gray-400 whitespace-pre-wrap">
                                 {tool.description}
                               </p>
                             )}
@@ -178,25 +183,23 @@ export const McpServerCard = ({
                           {Object.keys((tool.input_args || {}).properties || {})
                             .length > 0 && (
                             <Collapsible>
-                              <CollapsibleTrigger className="text-official-gray-400 mt-1 flex w-full cursor-pointer items-center justify-between py-1 text-left underline hover:text-white">
-                                <span className="text-xs">
-                                  View Input Parameters
-                                </span>
-                                <ChevronDown className="ml-auto size-4" />
+                              <CollapsibleTrigger className="group mt-3 flex w-full cursor-pointer items-center justify-between text-sm underline text-blue-400 hover:text-blue-300">
+                                <span>View input parameters</span>
+                                <ChevronDown className="ml-auto size-4 transition-transform duration-200 group-data-[state=open]:rotate-180" />
                               </CollapsibleTrigger>
-                              <CollapsibleContent className="pt-0">
-                                <div className="grid gap-2 rounded-lg p-3 py-1">
+                              <CollapsibleContent className="pt-2">
+                                <div className="grid gap-2 rounded-lg">
                                   {Object.keys(
                                     (tool.input_args || {}).properties || {},
                                   ).map((key) => (
                                     <div
-                                      className="flex flex-col gap-0.5"
+                                      className="flex flex-wrap items-baseline gap-2"
                                       key={key}
                                     >
                                       <span className="text-sm font-medium text-white">
                                         {key}
                                       </span>
-                                      <span className="text-official-gray-400 text-xs">
+                                      <span className="text-official-gray-400 whitespace-pre-wrap text-xs">
                                         {
                                           tool.input_args?.properties?.[key]
                                             ?.description
@@ -212,14 +215,14 @@ export const McpServerCard = ({
                       ))}
                     </ul>
                   ) : (
-                    <p className="text-sm text-gray-400">
+                    <p className="text-official-gray-300 text-base">
                       {t('mcpServers.noToolsAvailableForThisServer')}
                     </p>
                   )}
                 </div>
                 <DialogFooter>
                   <DialogClose asChild>
-                    <Button size="md" type="button" variant="outline">
+                    <Button className="mt-2" size="md" type="button" variant="outline">
                       Close
                     </Button>
                   </DialogClose>

--- a/libs/shinkai-ui/src/components/dialog.tsx
+++ b/libs/shinkai-ui/src/components/dialog.tsx
@@ -37,7 +37,7 @@ const DialogContent = ({
     <DialogOverlay />
     <DialogPrimitive.Content
       className={cn(
-        'bg-official-gray-950 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 border-official-gray-780 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:rounded-lg md:w-full',
+        'bg-official-gray-950 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 border-official-gray-780 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-120 sm:rounded-lg md:w-full',
 
         className,
       )}
@@ -46,11 +46,11 @@ const DialogContent = ({
       {children}
       <DialogPrimitive.Close
         className={cn(
-          'ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none',
+          'ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 inline-flex h-8 w-8 items-center justify-center rounded-md opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none',
           !showCloseButton && 'hidden',
         )}
       >
-        <X className="h-4 w-4" />
+        <X className="h-5 w-5" />
         <span className="sr-only">Close</span>
       </DialogPrimitive.Close>
     </DialogPrimitive.Content>


### PR DESCRIPTION
## Summary
- improve tools popup in MCP section with wider layout and better hierarchy
- enlarge dialog close button
- keep input descriptions inline with their names in the Tools modal

## Testing
- `npx nx test shinkai-desktop`

------
https://chatgpt.com/codex/tasks/task_e_683cbaf2b7e08321bee9af071600c932