### PR TITLE
Add agent details dialog

### DIFF
--- a/apps/shinkai-desktop/src/pages/network-agents.tsx
+++ b/apps/shinkai-desktop/src/pages/network-agents.tsx
@@ -11,6 +11,13 @@ import {
   TabsList,
   TabsTrigger,
   SearchInput,
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogTrigger,
+  PrettyJsonPrint,
 } from '@shinkai_network/shinkai-ui';
 import { cn } from '@shinkai_network/shinkai-ui/utils';
 import {
@@ -578,15 +585,31 @@ const AgentCard = ({ agent, type, isInstalled, onAdd }: AgentCardProps) => {
 
           <div className="flex gap-2">
             {type === 'discover' && (
-              <Button
-                variant={isInstalled ? 'secondary' : 'outline'}
-                className="w-full"
-                onClick={isInstalled ? undefined : handleAction}
-                disabled={isInstalled}
-                size="md"
-              >
-                {labels.buttonText}
-              </Button>
+              <>
+                <Button
+                  variant={isInstalled ? 'secondary' : 'outline'}
+                  className="flex-1"
+                  onClick={isInstalled ? undefined : handleAction}
+                  disabled={isInstalled}
+                  size="md"
+                >
+                  {labels.buttonText}
+                </Button>
+                <Dialog>
+                  <DialogTrigger asChild>
+                    <Button variant="outline" size="md">
+                      Details
+                    </Button>
+                  </DialogTrigger>
+                  <DialogContent showCloseButton className="max-w-xl">
+                    <DialogHeader>
+                      <DialogTitle>{agent.name}</DialogTitle>
+                      <DialogDescription>Agent details</DialogDescription>
+                    </DialogHeader>
+                    <PrettyJsonPrint json={agent.apiData ?? {}} />
+                  </DialogContent>
+                </Dialog>
+              </>
             )}
             {type === 'exposed' && (
               <div className="flex w-full flex-col gap-2">


### PR DESCRIPTION
## Summary
- add details dialog for network agent cards in network AI Agents page

## Testing
- `npx nx test shinkai-message-ts`
- `npx nx test shinkai-desktop`


------
https://chatgpt.com/codex/tasks/task_e_68412d7d8c548321bba09a0a822d6107