### PR TITLE
Add publish agent dialog

### DIFF
--- a/apps/shinkai-desktop/src/components/agent/publish-agent-dialog.tsx
+++ b/apps/shinkai-desktop/src/components/agent/publish-agent-dialog.tsx
@@ -1,0 +1,189 @@
+import { useState, useMemo } from 'react';
+import {
+  Dialog,
+  DialogTrigger,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+  Button,
+  SearchInput,
+  Input,
+} from '@shinkai_network/shinkai-ui';
+import {
+  type ShinkaiToolHeader,
+  type ToolOffering,
+  type ToolUsageType,
+} from '@shinkai_network/shinkai-message-ts/api/tools/types';
+import { useGetTools } from '@shinkai_network/shinkai-node-state/v2/queries/getToolsList/useGetToolsList';
+import { useGetToolsWithOfferings } from '@shinkai_network/shinkai-node-state/v2/queries/getToolsWithOfferings/useGetToolsWithOfferings';
+import { useSetToolOffering } from '@shinkai_network/shinkai-node-state/v2/mutations/setToolOffering/useSetToolOffering';
+import { useAuth } from '../../store/auth';
+
+export default function PublishAgentDialog() {
+  const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState('');
+  const [selected, setSelected] = useState<ShinkaiToolHeader | null>(null);
+  const [payTo, setPayTo] = useState('');
+  const [asset, setAsset] = useState('');
+  const [amount, setAmount] = useState('');
+  const [description, setDescription] = useState('');
+
+  const auth = useAuth((s) => s.auth);
+
+  const { data: tools } = useGetTools({
+    nodeAddress: auth?.node_address ?? '',
+    token: auth?.api_v2_key ?? '',
+    category: 'default',
+  });
+
+  const { data: offerings } = useGetToolsWithOfferings({
+    nodeAddress: auth?.node_address ?? '',
+    token: auth?.api_v2_key ?? '',
+  });
+
+  const publishedKeys = useMemo(
+    () => new Set((offerings ?? []).map((o) => o.tool_offering.tool_key)),
+    [offerings],
+  );
+
+  const filtered = useMemo(
+    () =>
+      (tools ?? []).filter((t) =>
+        t.name.toLowerCase().includes(search.toLowerCase()),
+      ),
+    [tools, search],
+  );
+
+  const { mutateAsync: publish, isPending } = useSetToolOffering({
+    onSuccess: () => {
+      setOpen(false);
+      setSelected(null);
+      setPayTo('');
+      setAsset('');
+      setAmount('');
+      setDescription('');
+    },
+  });
+
+  const handlePublish = async () => {
+    if (!selected) return;
+    const usage: ToolUsageType = {
+      PerUse: {
+        Payment: [
+          {
+            scheme: 'exact',
+            mimeType: 'application/json',
+            asset: asset,
+            outputSchema: {},
+            resource: 'https://shinkai.com',
+            extra: { name: asset, version: '1' },
+            payTo: payTo,
+            description: description,
+            maxTimeoutSeconds: 300,
+            network: 'base-sepolia',
+            maxAmountRequired: amount,
+          },
+        ],
+      },
+      Downloadable: { Payment: [] },
+    };
+
+    const offering: ToolOffering = {
+      meta_description: description,
+      tool_key: selected.tool_router_key,
+      usage_type: usage,
+    };
+
+    await publish({
+      nodeAddress: auth?.node_address ?? '',
+      token: auth?.api_v2_key ?? '',
+      offering,
+    });
+  };
+
+  return (
+    <Dialog onOpenChange={setOpen} open={open}>
+      <DialogTrigger asChild>
+        <Button variant="outline" size="sm">
+          Publish Agent
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="max-w-[600px]">
+        {selected ? (
+          <>
+            <DialogHeader>
+              <DialogTitle>Publish {selected.name}</DialogTitle>
+            </DialogHeader>
+            <div className="mt-4 space-y-2">
+              <Input
+                placeholder="Payment Address"
+                value={payTo}
+                onChange={(e) => setPayTo(e.target.value)}
+              />
+              <Input
+                placeholder="Asset"
+                value={asset}
+                onChange={(e) => setAsset(e.target.value)}
+              />
+              <Input
+                placeholder="Amount"
+                value={amount}
+                onChange={(e) => setAmount(e.target.value)}
+              />
+              <Input
+                placeholder="Description"
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+              />
+            </div>
+            <DialogFooter className="mt-4 flex justify-end gap-2">
+              <Button variant="secondary" onClick={() => setSelected(null)}>
+                Back
+              </Button>
+              <Button onClick={handlePublish} isLoading={isPending}>
+                Publish
+              </Button>
+            </DialogFooter>
+          </>
+        ) : (
+          <>
+            <DialogHeader>
+              <DialogTitle>Select Agent</DialogTitle>
+            </DialogHeader>
+            <SearchInput
+              placeholder="Search agents"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              classNames={{ input: 'bg-transparent' }}
+            />
+            <div className="mt-4 max-h-[50vh] space-y-2 overflow-y-auto">
+              {filtered?.map((tool) => (
+                <div
+                  key={tool.tool_router_key}
+                  className="hover:bg-official-gray-800 flex items-center justify-between gap-2 rounded p-2"
+                >
+                  <div>
+                    <p className="text-sm font-medium">{tool.name}</p>
+                    <p className="text-official-gray-400 line-clamp-1 text-xs">
+                      {tool.description}
+                    </p>
+                  </div>
+                  {publishedKeys.has(tool.tool_router_key) ? (
+                    <Button size="sm" variant="secondary" disabled>
+                      Published
+                    </Button>
+                  ) : (
+                    <Button size="sm" onClick={() => setSelected(tool)}>
+                      Publish
+                    </Button>
+                  )}
+                </div>
+              ))}
+            </div>
+          </>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/shinkai-desktop/src/pages/network-agents.tsx
+++ b/apps/shinkai-desktop/src/pages/network-agents.tsx
@@ -12,6 +12,7 @@ import {
   TabsTrigger,
   SearchInput,
 } from '@shinkai_network/shinkai-ui';
+import PublishAgentDialog from '../components/agent/publish-agent-dialog';
 import { cn } from '@shinkai_network/shinkai-ui/utils';
 import {
   Star,
@@ -117,7 +118,10 @@ export const NetworkAgentPage = () => {
         <TabsContent value="network">
           <DiscoverNetworkAgents />
         </TabsContent>
-        <TabsContent value="published">
+        <TabsContent value="published" className="space-y-4">
+          <div className="flex justify-end">
+            <PublishAgentDialog />
+          </div>
           <PublishedAgents />
         </TabsContent>
       </div>
@@ -132,7 +136,6 @@ export const NetworkAgentPage = () => {
     </Tabs>
   );
 };
-
 
 interface ApiPayment {
   maxAmountRequired?: string;
@@ -334,8 +337,7 @@ const PublishedAgents = () => {
   const publishedAgents = useMemo<Agent[]>(() => {
     if (!data) return [];
     return data.map((item) => {
-      const payment =
-        item.tool_offering.usage_type?.PerUse?.Payment?.[0];
+      const payment = item.tool_offering.usage_type?.PerUse?.Payment?.[0];
       const price = payment
         ? `${payment.maxAmountRequired} ${payment.extra?.name ?? ''}`
         : 'Free';

--- a/libs/shinkai-message-ts/src/api/tools/index.ts
+++ b/libs/shinkai-message-ts/src/api/tools/index.ts
@@ -64,6 +64,8 @@ import {
   type UpdateToolRequest,
   type UpdateToolResponse,
   type GetToolsWithOfferingsResponse,
+  type SetToolOfferingRequest,
+  type SetToolOfferingResponse,
 } from './types';
 
 export const createTool = async (
@@ -151,7 +153,10 @@ export const setCommonToolsetConfig = async (
   bearerToken: string,
   payload: SetCommonToolsetConfigRequest,
 ) => {
-  const response = await httpClient.post(urlJoin(nodeAddress, '/v2/set_common_toolset_config'), payload, {
+  const response = await httpClient.post(
+    urlJoin(nodeAddress, '/v2/set_common_toolset_config'),
+    payload,
+    {
       headers: { Authorization: `Bearer ${bearerToken}` },
       responseType: 'json',
     },
@@ -834,6 +839,22 @@ export const getToolsWithOfferings = async (
     },
   );
   return response.data as GetToolsWithOfferingsResponse;
+};
+
+export const setToolOffering = async (
+  nodeAddress: string,
+  bearerToken: string,
+  payload: SetToolOfferingRequest,
+) => {
+  const response = await httpClient.post(
+    urlJoin(nodeAddress, '/v2/set_tool_offering'),
+    payload,
+    {
+      headers: { Authorization: `Bearer ${bearerToken}` },
+      responseType: 'json',
+    },
+  );
+  return response.data as SetToolOfferingResponse;
 };
 
 export const setToolMcpEnabled = async (

--- a/libs/shinkai-message-ts/src/api/tools/types.ts
+++ b/libs/shinkai-message-ts/src/api/tools/types.ts
@@ -605,3 +605,11 @@ export type GetToolPlaygroundMetadataRequest = {
 };
 
 export type GetToolPlaygroundMetadataResponse = ToolMetadata | null;
+
+export type SetToolOfferingRequest = {
+  tool_offering: ToolOffering;
+};
+
+export type SetToolOfferingResponse = {
+  message: string;
+};

--- a/libs/shinkai-node-state/src/v2/mutations/setToolOffering/index.ts
+++ b/libs/shinkai-node-state/src/v2/mutations/setToolOffering/index.ts
@@ -1,0 +1,14 @@
+import { setToolOffering as setToolOfferingApi } from '@shinkai_network/shinkai-message-ts/api/tools/index';
+
+import { type SetToolOfferingInput } from './types';
+
+export const setToolOffering = async ({
+  nodeAddress,
+  token,
+  offering,
+}: SetToolOfferingInput) => {
+  const response = await setToolOfferingApi(nodeAddress, token, {
+    tool_offering: offering,
+  });
+  return response;
+};

--- a/libs/shinkai-node-state/src/v2/mutations/setToolOffering/types.ts
+++ b/libs/shinkai-node-state/src/v2/mutations/setToolOffering/types.ts
@@ -1,0 +1,12 @@
+import { type Token } from '@shinkai_network/shinkai-message-ts/api/general/types';
+import {
+  type ToolOffering,
+  type SetToolOfferingResponse,
+} from '@shinkai_network/shinkai-message-ts/api/tools/types';
+
+export type SetToolOfferingOutput = SetToolOfferingResponse;
+
+export type SetToolOfferingInput = Token & {
+  nodeAddress: string;
+  offering: ToolOffering;
+};

--- a/libs/shinkai-node-state/src/v2/mutations/setToolOffering/useSetToolOffering.ts
+++ b/libs/shinkai-node-state/src/v2/mutations/setToolOffering/useSetToolOffering.ts
@@ -1,0 +1,32 @@
+import {
+  useMutation,
+  type UseMutationOptions,
+  useQueryClient,
+} from '@tanstack/react-query';
+
+import { FunctionKeyV2 } from '../../constants';
+import { type APIError } from '../../types';
+import { type SetToolOfferingInput, type SetToolOfferingOutput } from './types';
+import { setToolOffering } from './index';
+
+export const useSetToolOffering = (
+  options?: UseMutationOptions<
+    SetToolOfferingOutput,
+    APIError,
+    SetToolOfferingInput
+  >,
+) => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: setToolOffering,
+    ...options,
+    onSuccess: async (data, variables, context) => {
+      await queryClient.invalidateQueries({
+        queryKey: [FunctionKeyV2.GET_TOOLS_WITH_OFFERINGS],
+      });
+      if (options?.onSuccess) {
+        options.onSuccess(data, variables, context);
+      }
+    },
+  });
+};


### PR DESCRIPTION
## Summary
- add PublishAgentDialog to list local agents and publish them
- show PublishAgentDialog button on Published Agents tab
- support setting tool offerings via new mutation and API

## Testing
- `npx nx format:check`


------
https://chatgpt.com/codex/tasks/task_e_68412e841a448321990cc1b3aaa5a6f5