### PR TITLE
Add Network tag in tool listing

### DIFF
--- a/apps/shinkai-desktop/src/components/tools/components/tool-card.tsx
+++ b/apps/shinkai-desktop/src/components/tools/components/tool-card.tsx
@@ -73,6 +73,11 @@ export default function ToolCard({ tool }: { tool: ShinkaiToolHeader }) {
               MCP
             </Badge>
           )}
+          {tool.tool_type === 'Network' && (
+            <Badge className="text-gray-80 bg-official-gray-750 text-xs font-normal">
+              Network
+            </Badge>
+          )}
           {tool.author !== '@@official.shinkai' && (
             <Badge className="text-gray-80 bg-official-gray-750 text-xs font-normal">
               {tool.author}


### PR DESCRIPTION
## Summary
- show 'Network' badge when a tool's type is Network

## Testing
- `npm run lint` in `apps/shinkai-desktop`
- `npx nx test shinkai-ui` *(fails: Cannot find configuration for task shinkai-ui:test)*

------
https://chatgpt.com/codex/tasks/task_e_684353d262208321b0d622bb3fbce706