### PR TITLE
Handle maxAmountRequired from PaymentRequest

### DIFF
--- a/apps/shinkai-desktop/src/components/chat/message-extra.tsx
+++ b/apps/shinkai-desktop/src/components/chat/message-extra.tsx
@@ -27,7 +27,8 @@ const truncateAddress = (address: string) => {
   return `${address.slice(0, 6)}...${address.slice(-4)}`;
 };
 
-const formatAmount = (amount: string, decimals = 18): string => {
+const formatAmount = (amount: string | undefined, decimals = 18): string => {
+  if (!amount) return '0';
   const value = BigInt(amount);
   const divisor = BigInt(10 ** decimals);
   const integerPart = value / divisor;
@@ -136,7 +137,9 @@ function Payment({
                             ? 'Free'
                             : 'Payment' in data.usage_type.PerUse
                               ? `${formatAmount(
-                                  data.usage_type.PerUse.Payment[0].amount,
+                                  data.usage_type.PerUse.Payment[0].amount ??
+                                    data.usage_type.PerUse.Payment[0].maxAmountRequired ??
+                                    '0',
                                   data.usage_type.PerUse.Payment[0].asset
                                     .decimals,
                                 )} ${
@@ -167,7 +170,10 @@ function Payment({
                             : 'Payment' in data.usage_type.Downloadable
                               ? `${formatAmount(
                                   data.usage_type.Downloadable.Payment[0]
-                                    .amount,
+                                    .amount ??
+                                    data.usage_type.Downloadable.Payment[0]
+                                      .maxAmountRequired ??
+                                    '0',
                                   data.usage_type.Downloadable.Payment[0].asset
                                     .decimals,
                                 )} ${

--- a/libs/shinkai-message-ts/src/api/tools/types.ts
+++ b/libs/shinkai-message-ts/src/api/tools/types.ts
@@ -248,7 +248,8 @@ export type ToolPrice =
   | { DirectDelegation: string }
   | {
       Payment: Array<{
-        amount: string;
+        amount?: string;
+        maxAmountRequired?: string;
         asset: {
           asset_id: string;
           contract_address: string;


### PR DESCRIPTION
## Summary
- handle PaymentRequest's `maxAmountRequired` in Payment widget
- update `ToolPrice` type to support `maxAmountRequired`

## Testing
- `npx nx test shinkai-message-ts`
- `npx nx test shinkai-desktop`


------
https://chatgpt.com/codex/tasks/task_e_6847a22df0088321865819b112193502