### PR TITLE
Fix add agent button in dialog

### DIFF
--- a/apps/shinkai-desktop/src/pages/network-agents.tsx
+++ b/apps/shinkai-desktop/src/pages/network-agents.tsx
@@ -23,6 +23,7 @@ import {
   DialogTitle,
   DialogDescription,
   DialogTrigger,
+  DialogClose,
   DialogFooter,
   Alert,
   AlertTitle,
@@ -647,16 +648,24 @@ const AgentCard = ({
 
                   {!isInstalled ? (
                     <DialogFooter className="flex-col gap-3 sm:flex-row">
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        className="w-full sm:w-auto"
-                      >
-                        Cancel
-                      </Button>
-                      <Button size="sm" className="w-full sm:w-auto">
-                        Add Agent
-                      </Button>
+                      <DialogClose asChild>
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          className="w-full sm:w-auto"
+                        >
+                          Cancel
+                        </Button>
+                      </DialogClose>
+                      <DialogClose asChild>
+                        <Button
+                          size="sm"
+                          className="w-full sm:w-auto"
+                          onClick={handleAction}
+                        >
+                          Add Agent
+                        </Button>
+                      </DialogClose>
                     </DialogFooter>
                   ) : (
                     <DialogFooter>


### PR DESCRIPTION
## Summary
- fix add agent button so it works inside the details dialog

## Testing
- `npx nx lint shinkai-desktop` *(fails: terminal crashed)*

------
https://chatgpt.com/codex/tasks/task_e_684a51e6a75c8321a97c587bbd0e226f