### PR TITLE
Fix token quota number formatting

### DIFF
--- a/apps/shinkai-desktop/src/pages/settings.tsx
+++ b/apps/shinkai-desktop/src/pages/settings.tsx
@@ -297,9 +297,9 @@ const SettingsPage = () => {
                   <span>Total tokens used</span>
                   <div className="flex items-center gap-1">
                     <span className="text-xs text-white">
-                      {shinkaiFreeModelQuota.usedTokens}{' '}
+                      {shinkaiFreeModelQuota.usedTokens.toLocaleString()}{' '}
                       <span className="text-official-gray-500 text-xs">
-                        / {shinkaiFreeModelQuota.tokensQuota}
+                        / {shinkaiFreeModelQuota.tokensQuota.toLocaleString()}
                       </span>
                     </span>
                     <Tooltip>


### PR DESCRIPTION
## Summary
- show numeric commas for token quota amounts in Settings

## Testing
- `npx nx run-many --target=test --projects=shinkai-desktop --nx-bail`

------
https://chatgpt.com/codex/tasks/task_e_684a523370588321854190ca238f4f94