### PR TITLE
Update stop button to call kill_job endpoint

### DIFF
--- a/apps/shinkai-desktop/src/components/chat/conversation-footer.tsx
+++ b/apps/shinkai-desktop/src/components/chat/conversation-footer.tsx
@@ -12,7 +12,7 @@ import {
 } from '@shinkai_network/shinkai-node-state/forms/chat/chat-message';
 import { DEFAULT_CHAT_CONFIG } from '@shinkai_network/shinkai-node-state/v2/constants';
 import { useSendMessageToJob } from '@shinkai_network/shinkai-node-state/v2/mutations/sendMessageToJob/useSendMessageToJob';
-import { useStopGeneratingLLM } from '@shinkai_network/shinkai-node-state/v2/mutations/stopGeneratingLLM/useStopGeneratingLLM';
+import { useKillJob } from '@shinkai_network/shinkai-node-state/v2/mutations/killJob/useKillJob';
 import { useGetAgents } from '@shinkai_network/shinkai-node-state/v2/queries/getAgents/useGetAgents';
 import { useGetChatConfig } from '@shinkai_network/shinkai-node-state/v2/queries/getChatConfig/useGetChatConfig';
 import { useGetJobFolderName } from '@shinkai_network/shinkai-node-state/v2/queries/getJobFolderName/useGetJobFolderName';
@@ -788,18 +788,17 @@ function StopGeneratingButtonBase({
   shouldStopGenerating: boolean;
 }) {
   const auth = useAuth((state) => state.auth);
-  const { mutateAsync: stopGenerating } = useStopGeneratingLLM();
+  const { mutateAsync: killJob } = useKillJob();
   const { inboxId: encodedInboxId = '' } = useParams();
   const inboxId = decodeURIComponent(encodedInboxId);
 
   const onStopGenerating = async () => {
     if (!inboxId) return;
     const decodedInboxId = decodeURIComponent(inboxId);
-    const jobId = extractJobIdFromInbox(decodedInboxId);
-    await stopGenerating({
+    await killJob({
       nodeAddress: auth?.node_address ?? '',
       token: auth?.api_v2_key ?? '',
-      jobId: jobId,
+      conversationInboxName: decodedInboxId,
     });
   };
 

--- a/libs/shinkai-message-ts/src/api/jobs/index.ts
+++ b/libs/shinkai-message-ts/src/api/jobs/index.ts
@@ -41,6 +41,8 @@ import {
   type RemoveLLMProviderRequest,
   type RetryMessageRequest,
   type StopGeneratingLLMRequest,
+  type KillJobRequest,
+  type KillJobResponse,
   type UpdateChatConfigRequest,
   type UpdateChatConfigResponse,
   type UpdateInboxNameRequest,
@@ -487,6 +489,22 @@ export const stopGeneratingLLM = async (
     },
   );
   return response.data;
+};
+
+export const killJob = async (
+  nodeAddress: string,
+  bearerToken: string,
+  payload: KillJobRequest,
+) => {
+  const response = await httpClient.post(
+    urlJoin(nodeAddress, '/v2/kill_job'),
+    payload,
+    {
+      headers: { Authorization: `Bearer ${bearerToken}` },
+      responseType: 'json',
+    },
+  );
+  return response.data as KillJobResponse;
 };
 
 export const getJobScope = async (

--- a/libs/shinkai-message-ts/src/api/jobs/types.ts
+++ b/libs/shinkai-message-ts/src/api/jobs/types.ts
@@ -267,6 +267,11 @@ export type UpdateChatConfigResponse = {
 export type StopGeneratingLLMRequest = string;
 export type StopGeneratingLLMResponse = { status: string };
 
+export type KillJobRequest = {
+  conversation_inbox_name: string;
+};
+export type KillJobResponse = { status: string };
+
 export type GetJobScopeRequest = {
   jobId: string;
 };

--- a/libs/shinkai-node-state/src/v2/mutations/killJob/index.ts
+++ b/libs/shinkai-node-state/src/v2/mutations/killJob/index.ts
@@ -1,0 +1,14 @@
+import { killJob as killJobApi } from '@shinkai_network/shinkai-message-ts/api/jobs/index';
+
+import { type KillJobInput } from './types';
+
+export const killJob = async ({
+  nodeAddress,
+  token,
+  conversationInboxName,
+}: KillJobInput) => {
+  const response = await killJobApi(nodeAddress, token, {
+    conversation_inbox_name: conversationInboxName,
+  });
+  return response;
+};

--- a/libs/shinkai-node-state/src/v2/mutations/killJob/types.ts
+++ b/libs/shinkai-node-state/src/v2/mutations/killJob/types.ts
@@ -1,0 +1,9 @@
+import { type Token } from '@shinkai_network/shinkai-message-ts/api/general/types';
+import { type KillJobResponse } from '@shinkai_network/shinkai-message-ts/api/jobs/types';
+
+export type KillJobOutput = KillJobResponse;
+
+export type KillJobInput = Token & {
+  nodeAddress: string;
+  conversationInboxName: string;
+};

--- a/libs/shinkai-node-state/src/v2/mutations/killJob/useKillJob.ts
+++ b/libs/shinkai-node-state/src/v2/mutations/killJob/useKillJob.ts
@@ -1,0 +1,29 @@
+import {
+  useMutation,
+  type UseMutationOptions,
+  useQueryClient,
+} from '@tanstack/react-query';
+
+import { FunctionKeyV2 } from '../../constants';
+import { type APIError } from '../../types';
+import { type KillJobInput, type KillJobOutput } from './types';
+import { killJob } from './index';
+
+type Options = UseMutationOptions<KillJobOutput, APIError, KillJobInput>;
+
+export const useKillJob = (options?: Options) => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: killJob,
+    ...options,
+    onSuccess: async (response, variables, context) => {
+      await queryClient.invalidateQueries({
+        queryKey: [FunctionKeyV2.GET_CHAT_CONFIG],
+      });
+
+      if (options?.onSuccess) {
+        options.onSuccess(response, variables, context);
+      }
+    },
+  });
+};


### PR DESCRIPTION
## Summary
- add killJob API call and types
- add killJob mutation hooks in node state library
- update conversation footer stop button to call kill job

## Testing
- `npx nx test` *(fails: Both project and target have to be specified)*
- `npx nx lint` *(fails: Both project and target have to be specified)*
- `npx tsc -p tsconfig.base.json --noEmit` *(fails with multiple JSX and type errors)*

------
https://chatgpt.com/codex/tasks/task_e_684b53238b9483218e20e4256411f7f3