### PR TITLE
Expose file upload button

### DIFF
--- a/apps/shinkai-desktop/src/pages/home.tsx
+++ b/apps/shinkai-desktop/src/pages/home.tsx
@@ -655,17 +655,6 @@ const EmptyMessage = () => {
                           <PopoverContent align="start" className="w-48 p-2">
                             <div className="flex flex-col items-start gap-1">
                               {!selectedTool && (
-                                <FileSelectionActionBar
-                                  disabled={!!selectedTool}
-                                  inputProps={{
-                                    ...chatForm.register('files'),
-                                    ...getInputFileProps(),
-                                  }}
-                                  onClick={openFilePicker}
-                                  showLabel
-                                />
-                              )}
-                              {!selectedTool && (
                                 <VectorFsActionBar
                                   aiFilesCount={
                                     Object.keys(selectedKeys || {}).length ?? 0
@@ -683,6 +672,18 @@ const EmptyMessage = () => {
                             </div>
                           </PopoverContent>
                         </Popover>
+
+                        {!selectedTool && (
+                          <FileSelectionActionBar
+                            disabled={!!selectedTool}
+                            inputProps={{
+                              ...chatForm.register('files'),
+                              ...getInputFileProps(),
+                            }}
+                            onClick={openFilePicker}
+                            showLabel
+                          />
+                        )}
 
                         {!selectedTool && !selectedAgent && (
                           <ToolsSwitchActionBar


### PR DESCRIPTION
## Summary
- make `Upload a File` directly visible on the new chat page

## Testing
- `npx nx lint shinkai-desktop` *(fails: process exited unexpectedly)*
- `npx nx test shinkai-desktop --skip-nx-cache` *(fails: process exited unexpectedly)*

------
https://chatgpt.com/codex/tasks/task_e_68571257a78c83219e03154fb007f01d