### PR TITLE
Add macOS Services integration

### DIFF
--- a/apps/shinkai-desktop/src-tauri/Cargo.lock
+++ b/apps/shinkai-desktop/src-tauri/Cargo.lock
@@ -774,6 +774,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "cocoa"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6140449f97a6e97f9511815c5632d84c8aacf8ac271ad77c559218161a1373c"
+dependencies = [
+ "bitflags 1.3.2",
+ "block",
+ "cocoa-foundation",
+ "core-foundation 0.9.4",
+ "core-graphics 0.23.2",
+ "foreign-types 0.5.0",
+ "libc",
+ "objc",
+]
+
+[[package]]
+name = "cocoa-foundation"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c6234cbb2e4c785b456c0644748b1ac416dd045799740356f8363dfe00c93f7"
+dependencies = [
+ "bitflags 1.3.2",
+ "block",
+ "core-foundation 0.9.4",
+ "core-graphics-types 0.1.3",
+ "libc",
+ "objc",
+]
+
+[[package]]
 name = "codespan-reporting"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5078,6 +5108,7 @@ dependencies = [
  "base64 0.22.1",
  "blake3",
  "chrono",
+ "cocoa",
  "ed25519-dalek",
  "fix-path-env",
  "futures-util",
@@ -5086,6 +5117,7 @@ dependencies = [
  "lazy_static",
  "listeners",
  "log",
+ "objc",
  "once_cell",
  "opener",
  "regex",

--- a/apps/shinkai-desktop/src-tauri/Cargo.toml
+++ b/apps/shinkai-desktop/src-tauri/Cargo.toml
@@ -56,6 +56,10 @@ tauri-plugin-http = "2.2"
 
 fix-path-env = { git = "https://github.com/tauri-apps/fix-path-env-rs" }
 
+[target.'cfg(target_os = "macos")'.dependencies]
+objc = "0.2"
+cocoa = "0.25"
+
 [features]
 # this feature is used for production builds or when `devPath` points to the filesystem
 # DO NOT REMOVE!!

--- a/apps/shinkai-desktop/src-tauri/Info.plist
+++ b/apps/shinkai-desktop/src-tauri/Info.plist
@@ -2,7 +2,27 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>CFBundleIdentifier</key>
-	<string>com.shinkai.desktop</string>
+    <key>CFBundleIdentifier</key>
+    <string>com.shinkai.desktop</string>
+    <key>NSServices</key>
+    <array>
+      <dict>
+        <key>NSMenuItem</key>
+        <dict>
+          <key>default</key>
+          <string>Ask Shinkai</string>
+        </dict>
+        <key>NSMessage</key>
+        <string>createChatService</string>
+        <key>NSPortName</key>
+        <string>Shinkai Desktop</string>
+        <key>NSRequiredContext</key>
+        <dict/>
+        <key>NSSendTypes</key>
+        <array>
+          <string>NSStringPboardType</string>
+        </array>
+      </dict>
+    </array>
 </dict>
 </plist>

--- a/apps/shinkai-desktop/src-tauri/src/macos_services.rs
+++ b/apps/shinkai-desktop/src-tauri/src/macos_services.rs
@@ -1,0 +1,55 @@
+#[cfg(target_os = "macos")]
+use cocoa::appkit::{NSApp, NSApplication};
+#[cfg(target_os = "macos")]
+use cocoa::base::id;
+#[cfg(target_os = "macos")]
+use objc::{class, msg_send, sel, sel_impl};
+#[cfg(target_os = "macos")]
+use objc::declare::ClassDecl;
+#[cfg(target_os = "macos")]
+use objc::runtime::{Object, Sel};
+
+#[cfg(target_os = "macos")]
+use once_cell::sync::OnceCell;
+
+#[cfg(target_os = "macos")]
+use crate::windows::{recreate_window, Window};
+
+#[cfg(target_os = "macos")]
+static APP_HANDLE: OnceCell<tauri::AppHandle> = OnceCell::new();
+
+#[cfg(target_os = "macos")]
+pub fn store_app_handle(handle: tauri::AppHandle) {
+    let _ = APP_HANDLE.set(handle);
+}
+
+#[cfg(target_os = "macos")]
+extern "C" fn create_chat_service(_: &Object, _: Sel, _: id, _: id, _: *mut id) {
+    unsafe {
+        if let Some(app) = APP_HANDLE.get() {
+            let _ = recreate_window(app.clone(), Window::Main, true);
+            if let Some(window) = app.get_webview_window("main") {
+                let _ = app.emit("create-chat", ());
+                let _ = window.set_focus();
+            }
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+pub fn register_services() {
+    unsafe {
+        let mut decl = ClassDecl::new("ShinkaiServiceProvider", class!(NSObject)).unwrap();
+        decl.add_method(sel!(createChatService:userData:error:), create_chat_service as extern "C" fn(&Object, Sel, id, id, *mut id));
+        let provider: id = msg_send![decl.register(), new];
+        let nsapp: id = NSApp();
+        let _: () = msg_send![nsapp, setServicesProvider: provider];
+        extern "C" { fn NSUpdateDynamicServices(); }
+        NSUpdateDynamicServices();
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+pub fn store_app_handle(_: tauri::AppHandle) {}
+#[cfg(not(target_os = "macos"))]
+pub fn register_services() {}

--- a/apps/shinkai-desktop/src-tauri/src/main.rs
+++ b/apps/shinkai-desktop/src-tauri/src/main.rs
@@ -45,6 +45,8 @@ mod globals;
 mod hardware;
 mod local_shinkai_node;
 mod models;
+#[cfg(target_os = "macos")]
+mod macos_services;
 mod tray;
 mod windows;
 
@@ -151,6 +153,12 @@ fn main() {
 
             create_tray(app.handle())?;
             setup_deep_links(app.handle())?;
+
+            #[cfg(target_os = "macos")]
+            {
+                macos_services::store_app_handle(app.handle());
+                macos_services::register_services();
+            }
 
             /*
                 This is the initialization pipeline


### PR DESCRIPTION
## Summary
- register a new macOS Service that triggers `create-chat`
- update `Info.plist` to advertise the "Ask Shinkai" service
- expose registration via new `macos_services` module
- hook the service into the app during setup

## Testing
- `cargo check --manifest-path apps/shinkai-desktop/src-tauri/Cargo.toml` *(fails: glib-2.0 not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a736a62008321af57990e4dafb61b